### PR TITLE
Put Patch and Delete requests handling for C# and Javascript

### DIFF
--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -182,7 +182,7 @@ namespace CodeSnippetsReflection.Test
         }
         #endregion
 
-        #region Test GetClassNameFromIdentifier
+        #region Test GetEdmTypeFromIdentifier
         [Fact]
         public void GetClassNameFromIdentifier_ShouldReturnRootIdentifierOnFirstSearch()
         {
@@ -196,10 +196,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.person", result);
+            Assert.Equal("microsoft.graph.person", result.ToString());
         }
 
         [Fact]
@@ -215,10 +215,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.message", result);
+            Assert.Equal("microsoft.graph.message", result.ToString());
         }
 
         [Fact]
@@ -235,10 +235,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.recipient", result);
+            Assert.Equal("microsoft.graph.recipient", result.ToString());
 
         }
 
@@ -256,10 +256,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.itemBody", result);
+            Assert.Equal("microsoft.graph.itemBody", result.ToString());
 
         }
 
@@ -278,10 +278,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.emailAddress", result);
+            Assert.Equal("microsoft.graph.emailAddress", result.ToString());
         }
 
         [Fact]
@@ -299,10 +299,10 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
             //Act
-            var result = CommonGenerator.GetClassNameFromIdentifier(snippetModel.Segments.Last(), path);
+            var result = CommonGenerator.GetEdmTypeFromIdentifier(snippetModel.Segments.Last(), path);
 
             //Assert
-            Assert.Equal("microsoft.graph.emailAddress", result);
+            Assert.Equal("microsoft.graph.emailAddress", result.ToString());
         }
         #endregion
     }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OData.UriParser;
+using Microsoft.OData.UriParser;
 using Newtonsoft.Json;
 using System;
 using System.Linq;
@@ -7,6 +7,7 @@ using System.Text;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Microsoft.OData.Edm;
 
 [assembly: InternalsVisibleTo("CodeSnippetsReflection.Test")]
 namespace CodeSnippetsReflection.LanguageGenerators
@@ -26,42 +27,32 @@ namespace CodeSnippetsReflection.LanguageGenerators
             try
             {
                 snippetBuilder.Append("GraphServiceClient graphClient = new GraphServiceClient( authProvider );\r\n\r\n");
-
+                var segment = snippetModel.Segments.Last();
                 if (snippetModel.Method == HttpMethod.Get)
                 {
-                    snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = await graphClient");
-                    //Generate the Resources path for Csharp
-                    snippetBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
-                    snippetBuilder.Append("\n\t.Request()");
-                    snippetBuilder.Append(CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions));
-                    //Append footers
-                    snippetBuilder.Append("\n\t.GetAsync();");
+                    var extraSnippet = "";
+                    if (segment is PropertySegment)
+                    { 
+                        extraSnippet = GeneratePropertySectionSnippet(snippetModel);
+                    }
+                    snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
+                    var actions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions) +"\n\t.GetAsync();";
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, actions));
+                    snippetBuilder.Append(extraSnippet);
 
                 }
                 else if (snippetModel.Method == HttpMethod.Post)
                 {
-                    var segment = snippetModel.Segments.Last();
-
                     switch (segment)
                     {
                         case NavigationPropertySegment _:
                         case EntitySetSegment _:
-                            if (!string.IsNullOrEmpty(snippetModel.RequestBody))
-                            {
-                                snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
-
-                                snippetBuilder.Append("await graphClient");
-                                //Generate the Resources path for Csharp
-                                snippetBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
-
-                                snippetBuilder.Append("\n\t.Request()");
-                                //Append footers
-                                snippetBuilder.Append($"\n\t.AddAsync({snippetModel.ResponseVariableName});");
-                            }
-                            else
-                            {
+                            if (string.IsNullOrEmpty(snippetModel.RequestBody))
                                 throw new Exception($"No request Body present for POST of entity {snippetModel.ResponseVariableName}");
-                            }
+
+                            snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\n\t.AddAsync({snippetModel.ResponseVariableName});"));
+
                             break;
 
                         case OperationSegment _:
@@ -75,17 +66,46 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 }
                             }
                             
-                            snippetBuilder.Append("await graphClient");
-                            //Generate the Resources path for Csharp
-                            snippetBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
-                            
-                            //Append footers
-                            snippetBuilder.Append("\n\t.Request()");
-                            snippetBuilder.Append("\n\t.PostAsync()");
+                            snippetBuilder.Append(GenerateRequestSection(snippetModel, "\n\t.PostAsync()"));
                             break;
                         default:
-                            throw new Exception("Unknown Segment Type in URI");
+                            throw new Exception("Unknown Segment Type in URI for method POST");
                     }
+                }
+                else if (snippetModel.Method == HttpMethod.Patch)
+                {
+                    if (string.IsNullOrEmpty(snippetModel.RequestBody))
+                        throw new Exception($"No request Body present for Patch of entity {snippetModel.ResponseVariableName}");
+                    
+                    snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
+                   
+                    if (segment is PropertySegment)
+                    {
+                        snippetBuilder.Append(GeneratePropertySectionSnippet(snippetModel));
+                    }
+
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel,$"\n\t.UpdateAsync({snippetModel.ResponseVariableName});"));
+                }
+                else if(snippetModel.Method == HttpMethod.Delete)
+                {
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, "\n\t.DeleteAsync();"));
+                }
+                else if (snippetModel.Method == HttpMethod.Put)
+                {
+                    if (string.IsNullOrEmpty(snippetModel.RequestBody))
+                        throw new Exception($"No request Body present for PUT of entity {snippetModel.ResponseVariableName}");
+
+                    if (snippetModel.ContentType.Equals("application/json"))
+                    {
+                        snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
+                    }
+                    else
+                    {
+                        snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = \"{snippetModel.RequestBody.Trim()}\"\n\n");
+                    }
+
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"\n\t.PutAsync({snippetModel.ResponseVariableName});"));
+
                 }
                 else
                 {
@@ -129,7 +149,10 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             {
                                 if ((parameter.Name.ToLower().Equals("bindingparameter")) || (parameter.Name.ToLower().Equals("bindparameter")))
                                     continue;
-                                paramList.Add(LowerCaseFirstLetter(parameter.Name));
+                                //append the suffix List if its a collection
+                                paramList.Add(parameter.Type.Definition is IEdmCollectionType
+                                    ? LowerCaseFirstLetter(parameter.Name + "List")
+                                    : LowerCaseFirstLetter(parameter.Name));
                             }
                             
                             resourcesPath.Append($"\n\t.{UppercaseFirstLetter(operationSegment.Identifier)}({CommonGenerator.GetListAsStringForSnippet(paramList,",")})");
@@ -159,7 +182,12 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             resourcesPath.Append($".{UppercaseFirstLetter(operationSegment.Identifier)}({CommonGenerator.GetListAsStringForSnippet(paramList,",")})");
                         }
                         break;
-
+                    case ValueSegment _:
+                        resourcesPath.Append(".Content");
+                        break;
+                    case PropertySegment _:
+                        //dont append anything since this is not accessed directly in C#
+                        break;
                     default:
                         //its most likely just a resource so append it
                         resourcesPath.Append($".{UppercaseFirstLetter(item.Identifier)}");
@@ -190,14 +218,18 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     break;
                 case JObject jObject:
                     {
-                        var className = CommonGenerator.GetClassNameFromIdentifier(pathSegment, path);
-                        className = UppercaseFirstLetter(className.Split(".").Last());
+                        var className = GetCsharpClassName(pathSegment,path);
                         stringBuilder.Append($"var {variableName} = new {className}\r\n");
                         stringBuilder.Append("{\r\n");//opening curly brace
-                                                      //initialize each member of the class
+                        //initialize each member/property of the object
                         foreach (var (key, jToken) in jObject)
                         {
                             var value = JsonConvert.SerializeObject(jToken);
+                            var newPath = path.Append(key).ToList();//add new identifier to the path
+                            if (key.Contains("@odata"))
+                            {
+                                continue;
+                            }
                             switch (jToken.Type)
                             {
                                 case JTokenType.Array:
@@ -205,12 +237,37 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     //we need to create a new object make sure variable names are unique
                                     stringBuilder = EnsureVariableNameIsUnique(stringBuilder, key);
                                     //new nested object needs to be constructed so call this function recursively to make it and append it before the current snippet
-                                    var newPath = path.Append(key).ToList();
-                                    //append this at the start since it needs to be declared before this object is constructed
                                     var newObject = CSharpGenerateObjectFromJson(pathSegment, value, newPath);
+                                    //append this at the start since it needs to be declared before this object is constructed
                                     stringBuilder.Insert(0, newObject);
-                                    //append the usage of declared variable
-                                    stringBuilder.Append($"\t{UppercaseFirstLetter(key)} = {key},\r\n");
+                                    //append the usage of declared variable depending on whether its an array or simple object
+                                    stringBuilder.Append(jToken.Type == JTokenType.Object
+                                        ? $"\t{UppercaseFirstLetter(key)} = {key},\r\n"
+                                        : $"\t{UppercaseFirstLetter(key)} = {key}List,\r\n");
+                                    break;
+                                case JTokenType.String:
+                                    var nestedEdmType = CommonGenerator.GetEdmTypeFromIdentifier(pathSegment, newPath);
+                                    //check if the type is an enum and handle it
+                                    if (nestedEdmType is IEdmEnumType edmEnumType)
+                                    {
+                                        var typeName = GetCsharpClassName(pathSegment, newPath);
+                                        var enumName = UppercaseFirstLetter(edmEnumType.Members.First().Name);//default to first member incase serach fails
+                                        //look for the proper name of the enum in the members
+                                        foreach (var member in edmEnumType.Members)
+                                        {
+                                            if (member.Name.Equals(jToken.Value<string>(), StringComparison.OrdinalIgnoreCase))
+                                            {
+                                                enumName = UppercaseFirstLetter(member.Name);
+                                            }
+                                        }
+                                        //Enum is accessed as the Classname then enum type e.g Importance.Low
+                                        stringBuilder.Append($"\t{UppercaseFirstLetter(key)} = { typeName }.{enumName},\r\n");
+                                    }
+                                    else
+                                    {
+                                        //its just a normal string. Declare as is
+                                        stringBuilder.Append($"\t{UppercaseFirstLetter(key)} = { value.Replace("\n", "").Replace("\r", "") },\r\n");
+                                    }
                                     break;
                                 default:
                                     stringBuilder.Append($"\t{UppercaseFirstLetter(key)} = { value.Replace("\n", "").Replace("\r", "") },\r\n");
@@ -223,32 +280,31 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     break;
                 case JArray array:
                     {
-                        var className = CommonGenerator.GetClassNameFromIdentifier(pathSegment, path);
-                        className = UppercaseFirstLetter(className.Split(".").Last());
+                        var className = GetCsharpClassName(pathSegment , path);
                         //Item is a list/array so declare a typed list
-                        stringBuilder.Append($"var {variableName} = new List<{className}>();\r\n");
+                        stringBuilder.Append($"var {variableName}List = new List<{className}>();\r\n");
                         var objectList = array.Children<JObject>();
                         if (objectList.Any())
                         {
                             foreach (var item in objectList)
                             {
-                                var paramList = new List<string>();
-                                //Add each object item to the list
-                                foreach (var (key, jToken) in item)
-                                {
-                                    //we need to create a new object make sure variable names are unique   
-                                    stringBuilder = EnsureVariableNameIsUnique(stringBuilder, key);
-                                    //nested object needs to be constructed so call this function recursively to make it and append it before the current snippet
-                                    var newPath = path.Append(key).ToList();
-                                    //create the new object and place it at the start
-                                    var jsonString = JsonConvert.SerializeObject(jToken);
-                                    var newObject = CSharpGenerateObjectFromJson(pathSegment, jsonString, newPath);
-                                    stringBuilder.Insert(0, newObject);
-                                    paramList.Add(key);
-                                }
-
                                 //append nested object to the list
-                                stringBuilder.Append($"{variableName}.Add(new {className}({CommonGenerator.GetListAsStringForSnippet(paramList, ",")}));\r\n");
+                                var jsonString = JsonConvert.SerializeObject(item);
+                                stringBuilder = EnsureVariableNameIsUnique(stringBuilder, path.Last());
+                                //we need to create a new object
+                                var objectItem = CSharpGenerateObjectFromJson(pathSegment, jsonString, path);
+                                //prepend the new object created before this declaration
+                                stringBuilder.Insert(0, objectItem);
+                                //add declared object to the list
+                                stringBuilder.Append($"{variableName}List.Add( {path.Last()} );\r\n");
+                            }
+                        }
+                        else
+                        {
+                            //its not nested objects but a string collection
+                            foreach (var element in array)
+                            {
+                                stringBuilder.Append($"{variableName}List.Add( \"{element.Value<string>()}\" );\r\n");
                             }
                         }
                     }
@@ -268,6 +324,91 @@ namespace CodeSnippetsReflection.LanguageGenerators
         }
 
         /// <summary>
+        /// Generate the snippet section that makes the call to the api
+        /// </summary>
+        /// <param name="snippetModel">Snippet model built from the request</param>
+        /// <param name="actions">String of actions to be done inside the code block</param>
+        private static string GenerateRequestSection(SnippetModel snippetModel, string actions)
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.Append("await graphClient");
+            //Generate the Resources path for Csharp
+            stringBuilder.Append(CSharpGenerateResourcesPath(snippetModel));
+            stringBuilder.Append("\n\t.Request()");
+            //Append footers
+            stringBuilder.Append(actions);
+
+            return stringBuilder.ToString();
+        }
+
+        /// <summary>
+        /// Return string representation of the classname for CSharp
+        /// </summary>
+        /// <param name="pathSegment">The OdataPathSegment in use</param>
+        /// <param name="path">Path to follow to get find the classname</param>
+        /// <returns>String representing the type in use</returns>
+        private static string GetCsharpClassName(ODataPathSegment pathSegment, ICollection<string> path)
+        {
+            var edmType = CommonGenerator.GetEdmTypeFromIdentifier(pathSegment, path);
+            //we need to split the string and get last item
+            //eg microsoft.graph.data => Data
+            return UppercaseFirstLetter( edmType.ToString().Split(".").Last() );
+        }
+
+        /// <summary>
+        /// Generate the snippet section for the Property segment for CSharp code as this section cannot be directly accessed in \
+        /// a URL fashion
+        /// </summary>
+        /// <param name="snippetModel">Snippet model built from the request</param>
+        private static string GeneratePropertySectionSnippet(SnippetModel snippetModel)
+        {
+            if (snippetModel.Segments.Count < 2)
+                return "";
+
+            var stringBuilder = new StringBuilder();
+            var desiredSegment = snippetModel.Segments.Last();
+            var segmentIndex = snippetModel.Segments.Count - 1;
+
+            //move back to find first segment that is not a PropertySegment
+            while ((desiredSegment is PropertySegment) && (segmentIndex > 0))
+            {
+                desiredSegment = snippetModel.Segments[--segmentIndex];
+            }
+
+            var selectField = snippetModel.Segments[segmentIndex+1].Identifier;
+
+            //generate path to the property
+            var properties = "";
+            while (segmentIndex < snippetModel.Segments.Count - 1)
+            {
+                properties = properties + "." + UppercaseFirstLetter(snippetModel.Segments[++segmentIndex].Identifier);
+            }
+
+            //modify the responseVarible name
+            snippetModel.ResponseVariableName = desiredSegment.Identifier;
+            var variableName = snippetModel.Segments.Last().Identifier;
+            var parentClassName = GetCsharpClassName(desiredSegment, new List<string> { snippetModel.ResponseVariableName });
+
+            
+            if (snippetModel.Method == HttpMethod.Get)
+            {
+                //we are retrieving the value
+                snippetModel.SelectFieldList.Add(selectField);
+                stringBuilder.Append($"\n\nvar {variableName} = {snippetModel.ResponseVariableName}{properties};");
+            }
+            else
+            {
+                //we are modifying the value
+                stringBuilder.Append($"var {snippetModel.ResponseVariableName} = new {parentClassName}();");//initialise the classname
+                stringBuilder.Append($"\n{snippetModel.ResponseVariableName}{properties} = {variableName};\n\n");
+            }
+
+            return stringBuilder.ToString();
+        }
+
+
+        /// <summary>
         /// Helper function to make check and ensure that a variable name has not been used in declaring another instance variable.
         /// If variable name exists, return string with modified name by appending "Var"
         /// </summary>
@@ -278,7 +419,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         {
             if (stringBuilder.ToString().Contains($"var {variableName} = "))
             {
-                stringBuilder.Replace(variableName, variableName + "Var");
+                stringBuilder.Replace(variableName+" ", "_" + variableName+" " );
             }
             return stringBuilder;
         }

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -24,6 +24,7 @@ namespace CodeSnippetsReflection
         public List<string> OrderByFieldList { get; set; }
         public IEnumerable<KeyValuePair<string, IEnumerable<string>>> RequestHeaders { get; set; }
         public string RequestBody { get; set; }
+        public string ContentType { get; set; }
 
         /// <summary>
         /// Model for the information needed to create a snippet from the request message
@@ -170,6 +171,8 @@ namespace CodeSnippetsReflection
             if (null != requestPayload.Content)
             {
                 this.RequestBody = await requestPayload.Content.ReadAsStringAsync();
+                if(null != requestPayload.Content.Headers.ContentType)
+                    this.ContentType = requestPayload.Content.Headers.ContentType.MediaType;
             }
             else
             {

--- a/c-sharp-examples.md
+++ b/c-sharp-examples.md
@@ -6,21 +6,21 @@ author: "andrueastman"
 
 # CSharp examples
 
-This shows how snippets requests look like for javascript
+This shows how snippets requests look like for C#
 
 ## Examples
 
-### Get Request
+### GET Request
 
-#### Example Get Request
+#### Example GET Request
 
 ```http
-GET /v1.0/me/events/AAMkAGIAAAoZDOFAAA=?$select=subject,body,bodyPreview,organizer,attendees,start,end,location
+GET /v1.0/me/events/AAMkAGIAAAoZDOFAAA=?$select=subject,body,bodyPreview,organizer,attendees,start,end,location HTTP/1.1
 Host: graph.microsoft.com
 Prefer: outlook.timezone="Pacific Standard Time"
 ```
 
-#### Example Get Request snippet generated
+#### Example GET Request snippet generated
 
 ```cs
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
@@ -37,7 +37,7 @@ var events = await graphClient.Me.Events["AAMkAGIAAAoZDOFAAA="]
 #### Example POST Request
 
 ```http
-POST /v1.0/users
+POST /v1.0/users HTTP/1.1
 Host: graph.microsoft.com
 Content-type: application/json
 
@@ -76,4 +76,96 @@ var user = new User
 await graphClient.Users
   .Request()
   .AddAsync(user);
+```
+
+### PATCH Request
+
+#### Example PATCH Request
+
+```http
+PATCH /v1.0/me HTTP/1.1
+Host: graph.microsoft.com
+Content-type: application/json
+Content-length: 491
+
+{
+  "accountEnabled": true,
+  "businessPhones": [
+    "businessPhones-value"
+  ],
+  "city": "city-value"
+}
+```
+
+#### Example PATCH Request snippet generated
+
+```cs
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+
+var businessPhones = new List<String>();
+
+var me = new User
+{
+  AccountEnabled = true,
+  BusinessPhones = businessPhones,
+  City = "city-value",
+};
+
+await graphClient.Me
+  .Request()
+  .UpdateAsync(me);
+```
+
+### PUT Request
+
+#### Example PUT Request
+
+```http
+PUT /beta/applications/{id}/synchronization/templates/{templateId} HTTP/1.1
+Host: graph.microsoft.com
+Authorization: Bearer <token>
+Content-type: application/json
+
+{
+    "id": "Slack",
+    "applicationId": "{id}",
+    "factoryTag": "CustomSCIM"
+}
+```
+
+#### Example PUT Request snippet generated
+
+```cs
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+
+var templates = new SynchronizationTemplate
+{
+  Id = "Slack",
+  ApplicationId = "{id}",
+  FactoryTag = "CustomSCIM",
+};
+
+await graphClient.Applications["{id}"].Synchronization.Templates["{templateId}"]
+  .Request()
+  .PutAsync(templates);
+```
+
+### DELETE Request
+
+#### Example DELETE Request
+
+```http
+DELETE /v1.0/me/messages/{id} HTTP/1.1
+Host: graph.microsoft.com
+
+```
+
+#### Example DELETE Request snippet generated
+
+```cs
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+
+await graphClient.Me.Messages["{id}"]
+  .Request()
+  .DeleteAsync();
 ```

--- a/javascript-examples.md
+++ b/javascript-examples.md
@@ -10,14 +10,15 @@ This shows how snippets requests look like for javascript
 
 ## Examples
 
-### Example 1
+### GET Request
 
-#### Get Request
+#### Example Get Request
 
 ```http
-GET /v1.0/me/events/AAMkAGIAAAoZDOFAAA=?$select=subject,body,bodyPreview,organizer,attendees,start,end,location
+GET /v1.0/me/events/AAMkAGIAAAoZDOFAAA=?$select=subject,body,bodyPreview,organizer,attendees,start,end,location HTTP/1.1
 Host: graph.microsoft.com
 Prefer: outlook.timezone="Pacific Standard Time"
+
 ```
 
 #### Snippet generated
@@ -40,7 +41,7 @@ let res = await client.api('/me/events/AAMkAGIAAAoZDOFAAA=')
 #### Example POST Request
 
 ```http
-POST /v1.0/users
+POST /v1.0/users HTTP/1.1
 Host: graph.microsoft.com
 Content-type: application/json
 
@@ -59,11 +60,6 @@ Content-type: application/json
 #### Example POST Request snippet generated
 
 ```javascript
-const options{
-  authProvider,
-};
-
-//initialise the client
 const options = {
   authProvider,
 };
@@ -83,4 +79,104 @@ const user = {
 
 let res = await client.api('/users')
   .post({user : user});
+```
+
+### PATCH Request
+
+#### Example PATCH Request
+
+```http
+PATCH /v1.0/me HTTP/1.1
+Host: graph.microsoft.com
+Content-type: application/json
+Content-length: 491
+
+{
+  "accountEnabled": true,
+  "businessPhones": [
+    "businessPhones-value"
+  ],
+  "city": "city-value"
+}
+```
+
+#### Example PATCH Request snippet generated
+
+```javascript
+const options = {
+  authProvider,
+};
+
+const client = Client.init(options);
+
+const me = {
+  accountEnabled: true,
+  businessPhones: [
+    "businessPhones-value"
+  ],
+  city: "city-value"
+};
+
+let res = await client.api('/me')
+  .update({user : me});
+```
+
+### PUT Request
+
+#### Example PUT Request
+
+```http
+PUT /beta/applications/{id}/synchronization/templates/{templateId} HTTP/1.1
+Host: graph.microsoft.com
+Authorization: Bearer <token>
+Content-type: application/json
+
+{
+    "id": "Slack",
+    "applicationId": "{id}",
+    "factoryTag": "CustomSCIM"
+}
+```
+
+#### Example PUT Request snippet generated
+
+```javascript
+const options = {
+  authProvider,
+};
+
+const client = Client.init(options);
+
+const templates = {
+    id: "Slack",
+    applicationId: "{id}",
+    factoryTag: "CustomSCIM"
+};
+
+let res = await client.api('/applications/{id}/synchronization/templates/{templateId}')
+  .version('beta')
+  .put({synchronizationTemplate : templates});
+```
+
+### DELETE Request
+
+#### Example DELETE Request
+
+```http
+DELETE /v1.0/me/messages/{id} HTTP/1.1
+Host: graph.microsoft.com
+
+```
+
+#### Example DELETE Request snippet generated
+
+```javascript
+const options = {
+  authProvider,
+};
+
+const client = Client.init(options);
+
+let res = await client.api('/me/messages/{id}')
+  .delete();
 ```


### PR DESCRIPTION
### Changes in this PR
- Add support for PUT, PATCH and DELETE method snippet generation for C# and JavaScript.( #20 #21 and #23)
-  Support for structural (PropertySegment) properties in C# that currently do not support direct access in a URL style. (#25 ) View example snippet [here](https://review.docs.microsoft.com/en-us/graph/api/user-get-mailboxsettings?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview-get-post-js-csharp&tabs=CS)
- Fixes for incorrect constructor generation and enum type lookup(#26 and #28 ) View example snippet [here](https://review.docs.microsoft.com/en-us/graph/api/user-post-messages?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview-get-post-js-csharp&tabs=CS)

Snippets generated by this branch can be found on the docs review site [here](https://review.docs.microsoft.com/en-us/graph/api/overview?toc=./ref/toc.json&view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview-get-post-js-csharp) under example requests on the pages. 
