### PR TITLE
Select expressions using anonymous objects and nested expand expressions

### DIFF
--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -129,6 +129,103 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal("\n\t.header('Prefer','kenya-timezone')", result);
         }
 
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpSelectExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users/{id}?$select=displayName,givenName,postalCode");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Select( e => new {\n\t\t\t e.displayName,\n\t\t\t e.givenName,\n\t\t\t e.postalCode \n\t\t\t })", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpFilterExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users?$filter=startswith(givenName, 'J')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Filter(\"startswith(givenName, 'J')\")", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpSearchExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/people/?$search=\"Irene McGowen\"");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Search(\"Irene McGowen\")", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpSkipExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/events?$skip=20");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Skip(20)", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpTopExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/events?$top=5");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Top(5)", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpRequestHeaderExpression()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users/{id}");
+            requestPayload.Headers.Add("Prefer", "kenya-timezone");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Header(\"Prefer\",\"kenya-timezone\")", result);
+        }
         #endregion
 
         #region Test GetListAsStringForSnippet

--- a/CodeSnippetsReflection.Test/SnippetsModelShould.cs
+++ b/CodeSnippetsReflection.Test/SnippetsModelShould.cs
@@ -13,7 +13,7 @@ namespace CodeSnippetsReflection.Test
         private readonly IEdmModel _edmModel = CsdlReader.Parse(XmlReader.Create(ServiceRootUrl + "/$metadata"));
 
         [Fact]
-        public void PopulateExpandListField()
+        public void PopulateExpandFieldExpression()
         {
             //Arrange
             var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/drive/root?$expand=children");
@@ -22,7 +22,48 @@ namespace CodeSnippetsReflection.Test
             var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
 
              //Assert
-            Assert.Equal("children", snippetModel.ExpandFieldList.First());
+            Assert.Equal("children", snippetModel.ExpandFieldExpression);
+        }
+
+        [Fact]
+        public void PopulateExpandFieldExpressionWithNestedQuery()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/drive/root?$expand=children($select=id,name)");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert
+            Assert.Equal("children($select=id,name)", snippetModel.ExpandFieldExpression);
+        }
+
+        [Fact]
+        public void PopulateExpandFieldExpressionFromMultipleQueryString()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users?$select=id,displayName,mail&$expand=extensions");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert
+            Assert.Equal("extensions", snippetModel.ExpandFieldExpression);
+
+        }
+
+        [Fact]
+        public void PopulateExpandFieldExpressionFromReversedMultipleQueryString()
+        {
+            //Reverse the query structure should still work
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users?$expand=extensions&$select=id,displayName,mail");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert
+            Assert.Equal("extensions", snippetModel.ExpandFieldExpression);
         }
 
         [Fact]

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -36,6 +36,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         extraSnippet = GeneratePropertySectionSnippet(snippetModel);
                     }
                     snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
+                    //Csharp properties are uppercase so replace with list with uppercase version
+                    snippetModel.SelectFieldList = snippetModel.SelectFieldList.Select(x => UppercaseFirstLetter(x)).ToList();
                     var actions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions) +"\n\t.GetAsync();";
                     snippetBuilder.Append(GenerateRequestSection(snippetModel, actions));
                     snippetBuilder.Append(extraSnippet);
@@ -462,14 +464,13 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string FilterExpression => "\n\t.Filter(\"{0}\")"; 
         public override string SearchExpression => "\n\t.Search(\"{0}\")"; 
         public override string ExpandExpression => "\n\t.Expand(\"{0}\")"; 
-        public override string SelectExpression => "\n\t.Select(\"{0}\")"; 
+        public override string SelectExpression => "\n\t.Select( e => new {{\n\t\t\t e.{0} \n\t\t\t }})"; 
         public override string OrderByExpression => "\n\t.OrderBy(\"{0}\")"; 
         public override string SkipExpression => "\n\t.Skip({0})"; 
         public override string SkipTokenExpression => "\n\t.SkipToken(\"{0}\")"; 
         public override string TopExpression => "\n\t.Top({0})";
         public override string FilterExpressionDelimiter => ",";
-        public override string ExpandExpressionDelimiter => ",";
-        public override string SelectExpressionDelimiter => ",";
+        public override string SelectExpressionDelimiter => ",\n\t\t\t e.";
         public override string OrderByExpressionDelimiter => " ";
         public override string HeaderExpression => "\n\t.Header(\"{0}\",\"{1}\")";
     }

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -41,12 +41,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 snippetBuilder.Append(string.Format(languageExpressions.SearchExpression, snippetModel.SearchExpression));
             }
 
-            //Append any expand queries
-            if (snippetModel.ExpandFieldList.Any())
+            //Append the expand section
+            if (!string.IsNullOrEmpty(snippetModel.ExpandFieldExpression))
             {
-                var expandResult = GetListAsStringForSnippet(snippetModel.ExpandFieldList, languageExpressions.ExpandExpressionDelimiter);
                 //append the expand result to the snippet
-                snippetBuilder.Append(string.Format(languageExpressions.ExpandExpression, expandResult));
+                snippetBuilder.Append(string.Format(languageExpressions.ExpandExpression, snippetModel.ExpandFieldExpression));
             }
 
             //Append any select queries

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -148,8 +148,6 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
         public override string FilterExpressionDelimiter => ",";
 
-        public override string ExpandExpressionDelimiter => ",";
-
         public override string SelectExpressionDelimiter => ",";
 
         public override string OrderByExpressionDelimiter => " ";

--- a/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
@@ -5,7 +5,6 @@
         public abstract string FilterExpression { get;  }
         public abstract string FilterExpressionDelimiter { get; }
         public abstract string ExpandExpression { get;  }
-        public abstract string ExpandExpressionDelimiter { get; }
         public abstract string SelectExpression { get;  }
         public abstract string SelectExpressionDelimiter { get; }
         public abstract string OrderByExpression { get;  }


### PR DESCRIPTION
This Pull request is proposes the following changes : -

- Resolving nested Expand expressions that would be truncated out if nested(#8) (You can preview snippet [here](https://review.docs.microsoft.com/en-us/graph/api/opentypeextension-get?view=graph-rest-beta&branch=andrueastman%2Fsnippets-preview-get-post-js-csharp&tabs=CS#sample-code-2)
- Updating select expressions in C# use anonymous objects (#29) (You can preview snippet [here](https://review.docs.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview-get-post-js-csharp&tabs=CS#sample-code)
- Unit tests have been added as well to increase coverage. 