### PR TITLE
Fixes for use of reserved keywords as variableNames

### DIFF
--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -217,5 +217,22 @@ namespace CodeSnippetsReflection.LanguageGenerators
             return result.ToString();
 
         }
+
+        /// <summary>
+        /// Helper function to make check and ensure that a variable name is not a reserved keyword for the language in use.
+        /// If it is reserved, return an appropiate transformation of the variale name 
+        /// </summary>
+        /// <param name="variableName">variable name to check for uniqueness</param>
+        /// <param name="languageExpressions">Language expressions that holds list of reserved words for filtering</param>
+        /// <returns>Modified variable name that is not a keyword</returns>
+        public static string EnsureVariableNameIsNotReserved(string variableName , LanguageExpressions languageExpressions)
+        {
+            if (languageExpressions.ReservedNames.Contains(variableName))
+            {
+                return "_" + variableName;//append an underscore
+            }
+
+            return variableName;
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -23,8 +23,21 @@ namespace CodeSnippetsReflection.LanguageGenerators
             try
             {
                 var snippetBuilder = new StringBuilder();
+                snippetModel.ResponseVariableName = CommonGenerator.EnsureVariableNameIsNotReserved(snippetModel.ResponseVariableName,languageExpressions);
                 //get the potential parameter for actions
-                var actionParameter = string.IsNullOrEmpty(snippetModel.RequestBody) ? "" : $"{{{GetObjectType(snippetModel.Segments.Last())} : { snippetModel.ResponseVariableName }}}";
+                var actionParameter = "";
+                if (!string.IsNullOrEmpty(snippetModel.RequestBody))
+                {
+                    var segment = snippetModel.Segments.Last();
+                    if (segment is OperationSegment)
+                    {
+                        actionParameter = $"{ snippetModel.ResponseVariableName }";
+                    }
+                    else
+                    {
+                        actionParameter = $"{{{GetObjectType(segment)} : { snippetModel.ResponseVariableName }}}";
+                    }
+                }
                 //setup the auth snippet section
                 snippetBuilder.Append("const options = {\n");
                 snippetBuilder.Append("\tauthProvider,\n};\n\n");
@@ -153,5 +166,16 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string OrderByExpressionDelimiter => " ";
 
         public override string HeaderExpression => "\n\t.header('{0}','{1}')";
+
+        public override string[] ReservedNames => new string [] {
+            "await","abstract", "arguments", "boolean", "break", "byte", "case",
+            "catch","char", "const", "continue", "debugger", "default", "delete",
+            "do","double", "else", "enum","export","extends","eval", "false", "final",
+            "finally", "float", "for","function", "goto", "if", "implements", "in",
+            "instanceof", "int","interface", "let", "long", "native", "new", "null",
+            "package","private", "protected", "public", "return", "short", "static",
+            "switch","synchronized", "this", "throw", "throws", "transient", "true",
+            "try","typeof", "var", "void", "volatile", "while", "with", "yield" };
+
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
@@ -14,6 +14,7 @@
         public abstract string TopExpression { get;  }
         public abstract string SearchExpression { get; }
         public abstract string HeaderExpression { get; }
+        public abstract string[] ReservedNames { get; }
 
     }
 }

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -56,14 +56,17 @@ namespace CodeSnippetsReflection
         /// <param name="oDataPathSegment">The pathe segment in question</param>
         private string GetResponseVariableName(ODataPathSegment oDataPathSegment)
         {
+            var edmType = oDataPathSegment.EdmType;
             //check if its a collection and try gate the name of single entity
-            if (oDataPathSegment.EdmType is IEdmCollectionType innerCollection )
+            if (edmType is IEdmCollectionType innerCollection )
             {
-                if(innerCollection.ElementType.Definition is IEdmNamedElement edmNamedElement)
-                    return edmNamedElement.Name;
+                edmType = innerCollection.ElementType.Definition;
             }
 
-            //its not a collection so the identfier can do
+            if (edmType is IEdmNamedElement edmNamedElement)
+                return edmNamedElement.Name;
+            
+            //its not a collection/or named type so the identfier can do
             return oDataPathSegment.Identifier;
         }
 


### PR DESCRIPTION
This pr mainly addresses the adding of checks to prevent use of variable names that are language specific keywords (i.e #31) 

The following changes are also included: 
- Also fixed Boolean types generations in C# that had upper case first letters.
- responseVariableName cleanup in snippet model to ensure consistent variable name generation.