### PR TITLE
Fix for incorrect pluralization of variable names

### DIFF
--- a/CodeSnippetsReflection.Test/SnippetsModelShould.cs
+++ b/CodeSnippetsReflection.Test/SnippetsModelShould.cs
@@ -164,7 +164,100 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal("",snippetModel.RequestBody);
         }
 
+        #region Test ResponseVariableNames
+        [Fact]
+        public void SetAppropriateVariableNameForPeopleEntity()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/people/");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "people" for a collection
+            Assert.Equal("people", snippetModel.ResponseVariableName);
+        }
+
+        [Fact]
+        public void SetAppropriateVariableNameForUsersList()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "users" for the users collection
+            Assert.Equal("users", snippetModel.ResponseVariableName);
+        }
 
 
+        [Fact]
+        public void SetAppropriateVariableNameForSingleUser()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/users/{id|userPrincipalName}");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "user" for the single user.
+            Assert.Equal("user", snippetModel.ResponseVariableName);
+
+        }
+
+        [Fact]
+        public void SetAppropriateVariableNameForChildrenItemsInDrive()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0//drives/{drive-id}/items/{item-id}/children");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "children" for the collection returned
+            Assert.Equal("children", snippetModel.ResponseVariableName);
+        }
+
+        [Fact]
+        public void SetAppropriateVariableNameForCalendarGroups()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/calendarGroups");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "calendarGroups" for the collection returned
+            Assert.Equal("calendarGroups", snippetModel.ResponseVariableName);
+        }
+
+        [Fact]
+        public void SetAppropriateVariableNameForEventCreate()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/events");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "event" (singular) as we are making a post call to create an entity
+            Assert.Equal("event", snippetModel.ResponseVariableName);
+        }
+
+        [Fact]
+        public void SetsAppropriateVariableNameForEventUpdate()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Patch, "https://graph.microsoft.com/v1.0/groups/{id}/events/{id}");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the variable name is "event" for an event update
+            Assert.Equal("event", snippetModel.ResponseVariableName);
+        }
+
+        #endregion
     }
 }

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -53,20 +53,25 @@ namespace CodeSnippetsReflection
         /// <summary>
         ///Get a string showing the name variable to be manipulated by the segment
         /// </summary>
-        /// <param name="oDataPathSegment">The pathe segment in question</param>
+        /// <param name="oDataPathSegment">The path segment in question</param>
+        /// <returns> string to be used as return variable name in this call.</returns>
         private string GetResponseVariableName(ODataPathSegment oDataPathSegment)
         {
             var edmType = oDataPathSegment.EdmType;
-            //check if its a collection and try gate the name of single entity
-            if (edmType is IEdmCollectionType innerCollection )
+
+            // when we are trying to create an entity(method == Post) make sure we try to get the name
+            // of a single item in the collection as we will be posting a single item.
+            if ((this.Method == HttpMethod.Post) && (edmType is IEdmCollectionType innerCollection))
             {
                 edmType = innerCollection.ElementType.Definition;
             }
 
             if (edmType is IEdmNamedElement edmNamedElement)
+            {
                 return edmNamedElement.Name;
+            }
             
-            //its not a collection/or named type so the identfier can do
+            //its not a collection/or named type so the identifier can do
             return oDataPathSegment.Identifier;
         }
 


### PR DESCRIPTION
This pull request proposes fixes to the pluralization of variable names generated by the snippet generator. (#40 )

Currently, the API detects that the ODataPathSegment is of a collection type and therefore blindly looks for the name in the ElementType and therefore cause the generated variable name to be always be in singular. 

However, this is incorrect as the returned name from the ODataPathSegment are suited just fine (NavigationProperty, EntitySet, NavigationLinkProperty or a KeySegment) as they will have they right pluralized form. 

The code has therefore been refactored to cater for the case of creating a new entity which will involve a POST method call to a possibly pluralized entity needing a singular version of the entity being created.

A number of unit tests have also been added to validate the fix proposed. 

Docs preview of the snippets generated by this branch can be viewed [here](https://review.docs.microsoft.com/en-us/graph/api/user-list?branch=andrueastman%2Fsnippets-preview&view=graph-rest-1.0&tabs=cs)