### PR TITLE
Concise Object Constrcution in Csharp

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -1,0 +1,178 @@
+﻿using CodeSnippetsReflection.LanguageGenerators;
+using System.Net.Http;
+using System.Xml;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Xunit;
+
+namespace CodeSnippetsReflection.Test
+{
+    public class CSharpGeneratorShould
+    {
+        private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
+        private readonly IEdmModel _edmModel = CsdlReader.Parse(XmlReader.Create(ServiceRootUrl + "/$metadata"));
+        private const string AuthProviderPrefix = "GraphServiceClient graphClient = new GraphServiceClient( authProvider );\r\n\r\n";
+
+        [Fact]
+        //This tests asserts that we can generate snippets from json objects with nested objects inside them.
+        public void RecursivelyGeneratesNestedPasswordProfileObjectFromJson()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //json string with nested object properties
+            const string userJsonObject = "{\r\n  \"accountEnabled\": true,\r\n  " +
+                                          "\"displayName\": \"displayName-value\",\r\n  " +
+                                          "\"mailNickname\": \"mailNickname-value\",\r\n  " +
+                                          "\"userPrincipalName\": \"upn-value@tenant-value.onmicrosoft.com\",\r\n " +
+                                          " \"passwordProfile\" : {\r\n    \"forceChangePasswordNextSignIn\": true,\r\n    \"password\": \"password-value\"\r\n  }\r\n}";//nested passwordProfile Object
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/users")
+            {
+                Content = new StringContent(userJsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel,expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var user = new User\r\n" +
+                                  "{\r\n" +
+                                      "\tAccountEnabled = true,\r\n" +
+                                      "\tDisplayName = \"displayName-value\",\r\n" +
+                                      "\tMailNickname = \"mailNickname-value\",\r\n" +
+                                      "\tUserPrincipalName = \"upn-value@tenant-value.onmicrosoft.com\",\r\n" +
+                                      "\tPasswordProfile = new PasswordProfile\r\n" +       //object with nested properties
+                                      "\t{\r\n" +
+                                          "\t\tForceChangePasswordNextSignIn = true,\r\n" + //nested object property
+                                          "\t\tPassword = \"password-value\"\r\n" +         //nested object property
+                                      "\t}\r\n" +
+                                  "};\r\n\r\n" +
+
+                                  "await graphClient.Users\n" +
+                                      "\t.Request()\n" +
+                                      "\t.AddAsync(user);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
+
+        [Fact]
+        //This tests asserts that we can generate snippets from json objects with nested arrays inside them.
+        public void RecursivelyGeneratesNestedPhonesListFromJsonObject()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //json string with nested objects string array
+            const string userJsonObject = "{\r\n  \"accountEnabled\": true,\r\n  " +
+                                          "\"businessPhones\": [\r\n    \"businessPhones-value\",\"businessPhones-value2\",\"businessPhones-value3\"\r\n  ],\r\n  " +//nested ArrayObject with 3 items
+                                          "\"city\": \"city-value\"\r\n}";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Patch, "https://graph.microsoft.com/v1.0/me")
+            {
+                Content = new StringContent(userJsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var user = new User\r\n" +
+                                           "{\r\n" +
+                                               "\tAccountEnabled = true,\r\n" +
+                                               "\tBusinessPhones = new List<String>()\r\n" +
+                                                //Array object
+                                               "\t{\r\n" +
+                                                   "\t\t\"businessPhones-value\",\r\n" +    //nested array item
+                                                   "\t\t\"businessPhones-value2\",\r\n" +   //nested array item
+                                                   "\t\t\"businessPhones-value3\"\r\n" +    //nested array item
+                                               "\t},\r\n" +
+                                               "\tCity = \"city-value\"\r\n" +
+                                           "};\r\n\r\n" +
+
+                                          "await graphClient.Me\n" +
+                                              "\t.Request()\n" +
+                                              "\t.UpdateAsync(user);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
+
+        [Fact]
+        //This tests asserts that we can generate snippets from json objects with nested object lists(JArray) inside them.
+        public void RecursivelyGeneratesNestedRecipientListObjectsFromJson()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //json string with nested object array
+            const string messageJsonObject = "{\r\n    " +
+                                                 "\"subject\":\"Did you see last night's game?\",\r\n" +
+                                                 "\"importance\":\"Low\",\r\n" +
+                                                 "\"body\":{\r\n" +
+                                                     "\"contentType\":\"HTML\",\r\n" +
+                                                     "\"content\":\"They were <b>awesome</b>!\"\r\n" +
+                                                "},\r\n" +
+                                                 "\"toRecipients\":[\r\n" +
+                                                         "{\r\n" +
+                                                             "\"emailAddress\":{\r\n" +
+                                                                "\"address\":\"AdeleV@contoso.onmicrosoft.com\"\r\n" +
+                                                             "}\r\n" +
+                                                         "},\r\n" +
+                                                         "{\r\n" +
+                                                             "\"emailAddress\":{\r\n" +
+                                                                "\"address\":\"AdeleV@contoso.onmicrosoft.com\"\r\n" +
+                                                             "}\r\n" +
+                                                         "}\r\n" +
+                                                     "]\r\n" +
+                                             "}";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/messages")
+            {
+                Content = new StringContent(messageJsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var message = new Message\r\n" +
+                                           "{\r\n" +
+                                               "\tSubject = \"Did you see last night's game?\",\r\n" +
+                                               "\tImportance = Importance.Low,\r\n" +
+                                               "\tBody = new ItemBody\r\n" +
+                                               "\t{\r\n" +
+                                                   "\t\tContentType = BodyType.Html,\r\n" +
+                                                   "\t\tContent = \"They were <b>awesome</b>!\"\r\n" +
+                                               "\t},\r\n" +
+                                               "\tToRecipients = new List<Recipient>()\r\n" +
+                                               "\t{\r\n" +
+                                                   "\t\tnew Recipient\r\n" +
+                                                   "\t\t{\r\n" +
+                                                   "\t\t\tEmailAddress = new EmailAddress\r\n" +
+                                                       "\t\t\t{\r\n" +
+                                                            "\t\t\t\tAddress = \"AdeleV@contoso.onmicrosoft.com\"\r\n" +
+                                                       "\t\t\t}\r\n" +
+                                                       "\t\t},\r\n" +
+                                                   "\t\tnew Recipient\r\n" +
+                                                   "\t\t{\r\n" +
+                                                       "\t\t\tEmailAddress = new EmailAddress\r\n" +
+                                                       "\t\t\t{\r\n" +
+                                                            "\t\t\t\tAddress = \"AdeleV@contoso.onmicrosoft.com\"\r\n" +
+                                                       "\t\t\t}\r\n" +
+                                                   "\t\t}\r\n" +
+                                               "\t}\r\n" +
+                                           "};\r\n\r\n" +
+
+                                          "await graphClient.Me.Messages\n" +
+                                              "\t.Request()\n" +
+                                              "\t.AddAsync(message);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+    }
+}

--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -130,6 +130,24 @@ namespace CodeSnippetsReflection.Test
         }
 
         [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateJavascriptRequestHeaderExpressionWithEscapedDoubleQuotes()
+        {
+            //Arrange
+            LanguageExpressions expressions = new JavascriptExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/events");
+            requestPayload.Headers.Add("Prefer", "outlook.timezone=\"Pacific Standard Time\"");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.header('Prefer','outlook.timezone=\"Pacific Standard Time\"')", result);
+        }
+
+        [Fact]
         public void GenerateQuerySection_ShouldReturnAppropriateCSharpSelectExpression()
         {
             //Arrange
@@ -225,6 +243,24 @@ namespace CodeSnippetsReflection.Test
 
             //Assert string is empty
             Assert.Equal("\n\t.Header(\"Prefer\",\"kenya-timezone\")", result);
+        }
+
+        [Fact]
+        public void GenerateQuerySection_ShouldReturnAppropriateCSharpRequestHeaderExpressionWithEscapedDoubleQuotes()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //no query present
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/events");
+            requestPayload.Headers.Add("Prefer", "outlook.timezone=\"Pacific Standard Time\"");
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act
+            var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
+
+            //Assert string is empty
+            Assert.Equal("\n\t.Header(\"Prefer\",\"outlook.timezone=\\\"Pacific Standard Time\\\"\")", result);
         }
         #endregion
 
@@ -400,6 +436,47 @@ namespace CodeSnippetsReflection.Test
 
             //Assert
             Assert.Equal("microsoft.graph.emailAddress", result.ToString());
+        }
+        #endregion
+
+        #region Test EnsureVariableNameIsNotReserved
+        [Fact]
+        public void EnsureVariableNameIsNotReserved_AppendsUnderscoreOnJavascriptKeywords()
+        {
+            //Arrange
+            LanguageExpressions expressions = new JavascriptExpressions();
+            var keyword = "transient";
+            //Act
+            var result = CommonGenerator.EnsureVariableNameIsNotReserved(keyword, expressions);
+
+            //Assert
+            Assert.Equal("_transient", result);
+        }
+
+        [Fact]
+        public void EnsureVariableNameIsNotReserved_AppendsTheAtSignOnCsharpKeywords()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var keyword = "event";
+            //Act
+            var result = CommonGenerator.EnsureVariableNameIsNotReserved(keyword, expressions);
+
+            //Assert
+            Assert.Equal("@event", result);
+        }
+
+        [Fact]
+        public void EnsureVariableNameIsNotReserved_DoesNotModifyVariableNamesIfNotReserved()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var keyword = "people";
+            //Act
+            var result = CommonGenerator.EnsureVariableNameIsNotReserved(keyword, expressions);
+
+            //Assert
+            Assert.Equal("people", result);
         }
         #endregion
     }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -281,6 +281,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     break;
                             }
                         }
+                        //remove the trailing comma if we appended anything
+                        if (stringBuilder[stringBuilder.Length - 3].Equals(','))
+                        {
+                            stringBuilder.Remove(stringBuilder.Length - 3, 1);
+                        }
                         //closing brace
                         stringBuilder.Append($"{tabSpace}}}\r\n");
                     }
@@ -303,6 +308,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                 objectStringFromJson = $"{tabSpace}\t{objectStringFromJson.Replace("\r\n", "\r\n\t")}";
                                 stringBuilder.Append($"{objectStringFromJson},\r\n");
                             }
+                            stringBuilder.Remove(stringBuilder.Length - 3, 1);//remove the trailing comma
                         }
                         else
                         {
@@ -310,6 +316,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             foreach (var element in array)
                             {
                                 stringBuilder.Append($"{tabSpace}\t\"{element.Value<string>()}\",\r\n");
+                            }
+                            //remove the trailing comma if we appended anything
+                            if (stringBuilder[stringBuilder.Length - 3].Equals(','))
+                            {
+                                stringBuilder.Remove(stringBuilder.Length - 3, 1);
                             }
                         }
                         stringBuilder.Append($"{tabSpace}}}\r\n");

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -25,7 +25,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 if (key.ToLower().Equals("host"))
                     continue;
                 //append the header to the snippet
-                snippetBuilder.Append(string.Format(languageExpressions.HeaderExpression, key, value.First()));
+                var valueString = value.First().Replace("\"", languageExpressions.DoubleQuotesEscapeSequence);
+                snippetBuilder.Append(string.Format(languageExpressions.HeaderExpression, key, valueString));
             }
             //Append any filter queries
             if (snippetModel.FilterFieldList.Any())
@@ -229,7 +230,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         {
             if (languageExpressions.ReservedNames.Contains(variableName))
             {
-                return "_" + variableName;//append an underscore
+                return languageExpressions.ReservedNameEscapeSequence + variableName;//append the language specific escape sequence
             }
 
             return variableName;

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -177,5 +177,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
             "switch","synchronized", "this", "throw", "throws", "transient", "true",
             "try","typeof", "var", "void", "volatile", "while", "with", "yield" };
 
+        public override string ReservedNameEscapeSequence => "_";
+
+        public override string DoubleQuotesEscapeSequence => "\"";
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/LanguageExpressions.cs
@@ -15,6 +15,7 @@
         public abstract string SearchExpression { get; }
         public abstract string HeaderExpression { get; }
         public abstract string[] ReservedNames { get; }
-
+        public abstract string ReservedNameEscapeSequence { get; }
+        public abstract string DoubleQuotesEscapeSequence { get; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The API takes in the HTTP request message to be sent to Microsoft Graph and the 
 
 The API currently supports the the generation of snippets to the Microsoft Graph API in the following languages
 
-- C# (POST and GET methods) 
-- Javascript (POST and GET methods)
+- C#
+- Javascript
 
 ## Example Snippets
 

--- a/c-sharp-examples.md
+++ b/c-sharp-examples.md
@@ -25,11 +25,20 @@ Prefer: outlook.timezone="Pacific Standard Time"
 ```cs
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-var events = await graphClient.Me.Events["AAMkAGIAAAoZDOFAAA="]
-  .Request()
-  .Header("Prefer","outlook.timezone="Pacific Standard Time"")
-  .Select("subject,body,bodyPreview,organizer,attendees,start,end,location")
-  .GetAsync();
+var @event = await graphClient.Me.Events["AAMkAGIAAAoZDOFAAA="]
+	.Request()
+	.Header("Prefer","outlook.timezone=\"Pacific Standard Time\"")
+	.Select( e => new {
+			 e.Subject,
+			 e.Body,
+			 e.BodyPreview,
+			 e.Organizer,
+			 e.Attendees,
+			 e.Start,
+			 e.End,
+			 e.Location 
+			 })
+	.GetAsync();
 ```
 
 ### POST Request
@@ -58,24 +67,22 @@ Content-type: application/json
 ```cs
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-var passwordProfile = new PasswordProfile
-{
-  ForceChangePasswordNextSignIn = true,
-  Password = "password-value",
-};
-
 var user = new User
 {
-  AccountEnabled = true,
-  DisplayName = "displayName-value",
-  MailNickname = "mailNickname-value",
-  UserPrincipalName = "upn-value@tenant-value.onmicrosoft.com",
-  PasswordProfile = passwordProfile,
+	AccountEnabled = true,
+	DisplayName = "displayName-value",
+	MailNickname = "mailNickname-value",
+	UserPrincipalName = "upn-value@tenant-value.onmicrosoft.com",
+	PasswordProfile = new PasswordProfile
+	{
+		ForceChangePasswordNextSignIn = true,
+		Password = "password-value",
+	},
 };
 
 await graphClient.Users
-  .Request()
-  .AddAsync(user);
+	.Request()
+	.AddAsync(user);
 ```
 
 ### PATCH Request
@@ -102,18 +109,19 @@ Content-length: 491
 ```cs
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-var businessPhones = new List<String>();
-
-var me = new User
+var user = new User
 {
-  AccountEnabled = true,
-  BusinessPhones = businessPhones,
-  City = "city-value",
+	AccountEnabled = true,
+	BusinessPhones = new List<String>()
+	{
+		"businessPhones-value",
+	},
+	City = "city-value",
 };
 
 await graphClient.Me
-  .Request()
-  .UpdateAsync(me);
+	.Request()
+	.UpdateAsync(user);
 ```
 
 ### PUT Request
@@ -138,16 +146,17 @@ Content-type: application/json
 ```cs
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-var templates = new SynchronizationTemplate
+var synchronizationTemplate = new SynchronizationTemplate
 {
-  Id = "Slack",
-  ApplicationId = "{id}",
-  FactoryTag = "CustomSCIM",
+	Id = "Slack",
+	ApplicationId = "{id}",
+	FactoryTag = "CustomSCIM",
 };
 
 await graphClient.Applications["{id}"].Synchronization.Templates["{templateId}"]
-  .Request()
-  .PutAsync(templates);
+	.Request()
+	.Header("Authorization","Bearer <token>")
+	.PutAsync(synchronizationTemplate);
 ```
 
 ### DELETE Request
@@ -166,6 +175,6 @@ Host: graph.microsoft.com
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
 await graphClient.Me.Messages["{id}"]
-  .Request()
-  .DeleteAsync();
+	.Request()
+	.DeleteAsync();
 ```


### PR DESCRIPTION
This Pull requests proposes the following changes :- 

- Concise Object Constructions in C Sharp (closes #34) See example [here](https://review.docs.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview&tabs=cs#sdk-sample-code)
- Escape double quotes in language specific fashion (closes #45) See example [here](https://review.docs.microsoft.com/en-us/graph/api/user-post-events?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview&tabs=cs#sdk-sample-code)
- Repeated variables resolved as we no longer use temporary variables (closes #43) View [here](https://review.docs.microsoft.com/en-us/graph/api/user-sendmail?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview&tabs=cs)
- Escape reserved keyword in a language specific fashion 
- Added unit tests and updated Readmes :-)