### PR TITLE
Support for Custom Query Options

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -174,5 +174,76 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This tests asserts that we can generate snippets with enums separate with Or binary action
+        public void GeneratesEnumTypesWithOrSeparatorIfEnumsAreMany()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            //json string with nested object array
+            const string messageJsonObject = "{\r\n    " +
+                                                 "\"EmailAddresses\": [\r\n" +
+                                                 "        \"danas@contoso.onmicrosoft.com\", \r\n" +
+                                                 "        \"fannyd@contoso.onmicrosoft.com\"\r\n" +
+                                                 "    ],\r\n" +
+                                                 "    \"MailTipsOptions\": \"automaticReplies, mailboxFullStatus\"\r\n" +//this is an enum that should be ORed together
+                                             "}";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/getMailTips")
+            {
+                Content = new StringContent(messageJsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var emailAddresses = new List<String>()\r\n" +
+                                           "{\r\n" +
+                                               "\t\"danas@contoso.onmicrosoft.com\",\r\n" +
+                                               "\t\"fannyd@contoso.onmicrosoft.com\"\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+                                           "var mailTipsOptions = MailTipsType.AutomaticReplies | MailTipsType.MailboxFullStatus;\r\n" + //Asserting that this OR is done
+                                           "\r\n" +
+                                           "await graphClient.Me\n" +
+                                               "\t.GetMailTips(emailAddresses,mailTipsOptions)\n" +
+                                               "\t.Request()\n" +
+                                               "\t.PostAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
+        [Fact]
+        //This tests asserts that we can generate snippets with enums separate with Or binary action
+        public void GeneratesSnippetsWithCustomQueryOptions()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,
+                "https://graph.microsoft.com/v1.0/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var queryOptions = new List<QueryOption>()\r\n" +
+                                           "{\r\n" +
+                                               "\tnew QueryOption(\"startDateTime\", \"2017-01-01T19:00:00.0000000\"),\r\n" +
+                                               "\tnew QueryOption(\"endDateTime\", \"2017-01-07T19:00:00.0000000\")\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+                                           "var calendarView = await graphClient.Me.Calendar.CalendarView\n" +
+                                               "\t.Request( queryOptions )\n" +
+                                               "\t.GetAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.Test/SnippetsModelShould.cs
+++ b/CodeSnippetsReflection.Test/SnippetsModelShould.cs
@@ -164,6 +164,22 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal("",snippetModel.RequestBody);
         }
 
+        [Fact]
+        public void PopulatesCustomQueryOptions()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000");
+
+            //Act
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Assert that the keys and values are as expected
+            Assert.Equal("startDateTime", snippetModel.CustomQueryOptions.First().Key);
+            Assert.Equal("2017-01-01T19:00:00.0000000", snippetModel.CustomQueryOptions.First().Value);
+            Assert.Equal("endDateTime", snippetModel.CustomQueryOptions.Last().Key);
+            Assert.Equal("2017-01-07T19:00:00.0000000", snippetModel.CustomQueryOptions.Last().Value);
+        }
+
         #region Test ResponseVariableNames
         [Fact]
         public void SetAppropriateVariableNameForPeopleEntity()

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -22,7 +22,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             foreach (var (key, value) in snippetModel.RequestHeaders)
             {
                 //no need to generate source for the host header
-                if (key.ToLower().Equals("host"))
+                if (key.ToLower().Equals("host",StringComparison.Ordinal))
                     continue;
                 //append the header to the snippet
                 var valueString = value.First().Replace("\"", languageExpressions.DoubleQuotesEscapeSequence);
@@ -156,7 +156,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             {
                 foreach (var property in structuredType.DeclaredProperties)
                 {
-                    if (property.Name.Equals(searchIdentifier))
+                    if (property.Name.Equals(searchIdentifier,StringComparison.OrdinalIgnoreCase))
                     {
                         elementDefinition = GetEdmElementType(property.Type.Definition);
                         
@@ -164,7 +164,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         if (searchPath.Count > 2)
                         {
                             //get rid of the root item and do a deeper search
-                            var subList = searchPath.Where(x => !x.Equals(searchPath.First())).ToList();
+                            var subList = searchPath.Where(x => !x.Equals(searchPath.First(), StringComparison.OrdinalIgnoreCase)).ToList();
                             return SearchForEdmType(property.Type.Definition, subList);
                         }
                         else

--- a/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaScriptGenerator.cs
@@ -108,7 +108,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <returns>String of the snippet in JS code</returns>
         private static string BetaSectionString(string apiVersion)
         {
-            return apiVersion.Equals("beta") ? "\n\t.version('beta')" : "";
+            return apiVersion.Equals("beta",StringComparison.Ordinal) ? "\n\t.version('beta')" : "";
         }
 
         /// <summary>
@@ -119,7 +119,13 @@ namespace CodeSnippetsReflection.LanguageGenerators
         private static string GenerateRequestSection(SnippetModel snippetModel, string actions)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append($"let res = await client.api('{snippetModel.Path}')");
+            var path = snippetModel.Path;
+            if (snippetModel.CustomQueryOptions.Any())
+            {
+                //just append the query string since its a custom query
+                path += snippetModel.QueryString;
+            }
+            stringBuilder.Append($"let res = await client.api('{path}')");
             //append beta
             stringBuilder.Append(BetaSectionString(snippetModel.ApiVersion));
             stringBuilder.Append(actions);


### PR DESCRIPTION
This PR proposes the following changes.

- Added support for custom query options in JS and csharp snippets (closes #42 ) View [example](https://review.docs.microsoft.com/en-us/graph/api/calendar-list-calendarview?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview&tabs=cs)
- Added support for multiple enums in csharp (with common handling) (closes #48 ) View [here](https://review.docs.microsoft.com/en-us/graph/api/user-getmailtips?view=graph-rest-1.0&branch=andrueastman%2Fsnippets-preview&tabs=cs).
- Updated string function calls to explicitly use a declared comparison type
- Added unit tests :)