### PR TITLE
Support for odata $ref in Csharp

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -267,5 +267,80 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This tests asserts that we can generate snippets with $ref that adds/creates references
+        public void GeneratesSnippetsAddingReferencesToObject()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            const string messageJsonObject = "{\r\n  \"@odata.id\": \"https://graph.microsoft.com/v1.0/users/{id}\"\r\n}";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/groups/{id}/owners/$ref")
+            {
+                Content = new StringContent(messageJsonObject)
+            };
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var directoryObject = new DirectoryObject\r\n" +
+                                           "{\r\n" +
+                                                "\tAdditionalData = new Dictionary<string, object>()\r\n" +
+                                                "\t{\r\n" +
+                                                    "\t\t{\"@odata.id\",\"https://graph.microsoft.com/v1.0/users/{id}\"}\r\n" +
+                                                "\t}\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+
+                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
+                                                "\n\t.Request()" +
+                                                "\n\t.AddAsync(directoryObject);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
+        [Fact]
+        //This tests asserts that we can generate snippets with $ref that adds/creates references with multiple additionalData inserted
+        public void GeneratesSnippetsAddingReferencesToObjectWithMultipleAdditionalData()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            const string messageJsonObject = "{\r\n  " +
+                                             "\"@odata.id\": \"https://graph.microsoft.com/v1.0/users/{id}\" ," +
+                                             "\"@odata.type\": \"#microsoft.graph.user\"" +
+                                             "\r\n}";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/groups/{id}/owners/$ref")
+            {
+                Content = new StringContent(messageJsonObject)
+            };
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var directoryObject = new DirectoryObject\r\n" +
+                                           "{\r\n" +
+                                           "\tAdditionalData = new Dictionary<string, object>()\r\n" +
+                                           "\t{\r\n" +
+                                           "\t\t{\"@odata.type\",\"#microsoft.graph.user\"},\r\n" +
+                                           "\t\t{\"@odata.id\",\"https://graph.microsoft.com/v1.0/users/{id}\"}\r\n" +
+                                           "\t}\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+
+                                           "await graphClient.Groups[\"{id}\"].Owners.References" +
+                                           "\n\t.Request()" +
+                                           "\n\t.AddAsync(directoryObject);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -245,5 +245,27 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This tests asserts that we can generate snippets with $ref operator inside it
+        public void GeneratesSnippetsWithReferenceSegmentInPath()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Delete,"https://graph.microsoft.com/v1.0/groups/{id}/owners/{id}/$ref");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "await graphClient.Groups[\"{id}\"].Owners[\"{id}\"].Reference\n" +
+                                        "\t.Request()\n" +
+                                        "\t.DeleteAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }


### PR DESCRIPTION
This PR closes #53 by the following actions. 
- Added support for odata $ref (ReferenceSegement)
- Added test to validate the behavior

Preview fix [here](https://docs.microsoft.com/en-us/graph/api/group-delete-owners?view=graph-rest-1.0&tabs=csharp#request)