### PR TITLE
Fix for incorrect string parameters for action parameters

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -342,5 +342,29 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This tests asserts that we can properly generate snippets for odata actions with parameters
+        public void GeneratesSnippetsForOdataActionsWithParameters()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,
+                "https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id|name}/range(address='A1:B2')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var workbookRange = await graphClient.Me.Drive.Items[\"{id}\"].Workbook.Worksheets[\"{id|name}\"]\n" +
+                                               "\t.Range(\"A1:B2\")\n" +//parameter has double quotes
+                                               "\t.Request()\n" +
+                                               "\t.GetAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Xml;
+using Microsoft.OData.UriParser;
 using Xunit;
 
 namespace CodeSnippetsReflection.Test
@@ -478,6 +479,25 @@ namespace CodeSnippetsReflection.Test
             //Assert
             Assert.Equal("people", result);
         }
+        #endregion
+
+        #region Test GetParameterListFromOperationSegment
+
+        [Fact]
+        public void GetParameterListFromOperationSegment_ShouldReturnStringWithDoubleQuotesForOdataActionParameter()
+        {
+            //Arrange
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id|name}/range(address='A1:B2')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            var operationSegment = snippetModel.Segments.Last() as OperationSegment;
+
+            //Act
+            var result = CommonGenerator.GetParameterListFromOperationSegment(operationSegment, snippetModel.Method);
+
+            //Assert the string parameter is now double quoted
+            Assert.Equal("\"A1:B2\"", result.First());
+        }
+
         #endregion
     }
 }

--- a/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
@@ -267,5 +267,29 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This tests asserts that we can properly generate snippets for odata actions with parameters
+        public void GeneratesSnippetsForOdataActionsWithParameters()
+        {
+            //Arrange
+            LanguageExpressions expressions = new JavaExpressions();
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get,
+                "https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id|name}/range(address='A1:B2')");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = JavaGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "WorkbookRange workbookRange = graphClient.me().drive().items(\"{id}\").workbook().worksheets(\"{id|name}\")\n" +
+                                           "\t.range(\"A1:B2\")\n" +//parameter has double quotes
+                                           "\t.buildRequest()\n" +
+                                           "\t.get();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -286,7 +286,9 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 //read parameters from request body since this is an odata action
                 foreach (var parameter in operationSegment.Operations.First().Parameters)
                 {
-                    if ((parameter.Name.ToLower().Equals("bindingparameter")) || (parameter.Name.ToLower().Equals("bindparameter")))
+                    if ((parameter.Name.ToLower().Equals("bindingparameter")) 
+                        || (parameter.Name.ToLower().Equals("bindparameter")) 
+                        || (parameter.Name.ToLower().Equals("this")))
                         continue;
 
                     paramList.Add(parameter.Type.Definition is IEdmCollectionType
@@ -305,7 +307,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             {
                                 if (convertNode.Source is ConstantNode constantNode)
                                 {
-                                    paramList.Add(constantNode.LiteralText);
+                                    paramList.Add($"\"{constantNode.Value}\"");
                                 }
                                 break;
                             }


### PR DESCRIPTION
This PR closes #76 where snippets generated lack appropriate double quotes for parameters in causing the snippets to not compile in java/csharp.

Ideally, instead of the range parameter having single quotes as below,

```GraphServiceClient graphClient = new GraphServiceClient( authProvider );
var workbookRange = await graphClient.Me.Drive.Items["{id}"].Workbook.Worksheets["{id|name}"]
	.Range('A1:B2')
	.Request()
	.GetAsync();
```

the snippet should be like this with a double quoted parameter. 

```GraphServiceClient graphClient = new GraphServiceClient( authProvider );
var workbookRange = await graphClient.Me.Drive.Items["{id}"].Workbook.Worksheets["{id|name}"]
	.Range("A1:B2")
	.Request()
	.GetAsync();
```

Unit tests have been added to verify that the snippets generated are as expected 😸 