### PR TITLE
Removing the empty-list check when adding new sample queries to an empty json file

### DIFF
--- a/GraphExplorerSamplesService/Services/SamplesService.cs
+++ b/GraphExplorerSamplesService/Services/SamplesService.cs
@@ -99,9 +99,9 @@ namespace GraphExplorerSamplesService.Services
         /// <returns>The instance of a <see cref="SampleQueriesList"/> with the newly added <see cref="SampleQueryModel"/> object.</returns>
         public static SampleQueriesList AddToSampleQueriesList(SampleQueriesList sampleQueriesList, SampleQueryModel sampleQueryModel)
         {
-            if (sampleQueriesList == null || sampleQueriesList.SampleQueries.Count == 0)
+            if (sampleQueriesList == null)
             {
-                throw new ArgumentNullException(nameof(sampleQueriesList), "The list of sample queries cannot be null or empty.");
+                throw new ArgumentNullException(nameof(sampleQueriesList), "The list of sample queries cannot be null.");
             }
             if (sampleQueryModel == null)
             {

--- a/SamplesService.Test/SamplesServiceShould.cs
+++ b/SamplesService.Test/SamplesServiceShould.cs
@@ -436,6 +436,34 @@ namespace SamplesService.Test
         #region Add To Sample Queries List Tests
 
         [Fact]
+        public void AddSampleQueryIntoEmptyListOfSampleQueries()
+        {
+            /* Arrange */
+
+            SampleQueriesList sampleQueriesList = new SampleQueriesList(new List<SampleQueryModel>());
+
+            SampleQueryModel sampleQueryModel = new SampleQueryModel()
+            {
+                Id = Guid.Parse("3482cc10-f2be-40fc-bcdb-d3ac35f3e4c3"),
+                Category = "Getting Started",
+                Method = SampleQueryModel.HttpMethods.GET,
+                HumanName = "my manager",
+                RequestUrl = "/v1.0/me/manager",
+                DocLink = "https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/user_list_manager",
+                SkipTest = false
+            };
+
+            /* Act */
+
+            // Add the new sample query to the empty list of sample queries
+            sampleQueriesList = GraphExplorerSamplesService.Services.SamplesService.AddToSampleQueriesList
+                (sampleQueriesList, sampleQueryModel);
+
+            // Assert
+            Assert.NotEmpty(sampleQueriesList.SampleQueries);
+        }
+
+        [Fact]
         public void AddSampleQueryIntoListOfSampleQueriesInHierarchicalOrderOfCategories()
         {
             /* Arrange */

--- a/SamplesService.Test/SamplesServiceShould.cs
+++ b/SamplesService.Test/SamplesServiceShould.cs
@@ -502,14 +502,12 @@ namespace SamplesService.Test
         }
 
         [Fact]
-        public void ThrowArgumentNullExceptionIfAddToSampleQueriesListSampleQueriesListParameterIsNullOrEmpty()
+        public void ThrowArgumentNullExceptionIfAddToSampleQueriesListSampleQueriesListParameterIsNull()
         {
             /* Arrange */
 
             SampleQueriesList nullSampleQueriesList = null;
-
-            SampleQueriesList emptySampleQueriesList = new SampleQueriesList(new List<SampleQueryModel>());
-
+            
             SampleQueryModel sampleQueryModel = new SampleQueryModel()
             {
                 Id = Guid.Parse("3482cc10-f2be-40fc-bcdb-d3ac35f3e4c3"),
@@ -529,10 +527,6 @@ namespace SamplesService.Test
             // Null sample queries list
             Assert.Throws<ArgumentNullException>(() => 
                 GraphExplorerSamplesService.Services.SamplesService.AddToSampleQueriesList(nullSampleQueriesList, sampleQueryModel));
-
-            // Empty sample queries list
-            Assert.Throws<ArgumentNullException>(() => 
-                GraphExplorerSamplesService.Services.SamplesService.AddToSampleQueriesList(emptySampleQueriesList, sampleQueryModel));
         }
 
         [Fact]


### PR DESCRIPTION
This PR closes #84 
Change proposed:
- It should be possible to add a new sample query to an empty sample queries list.