### PR TITLE
Fixing null evaluations and empty scopes to return nulls when getting permission scopes

### DIFF
--- a/GraphExplorerPermissionsService/Interfaces/IPermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionsStore.cs
@@ -6,6 +6,6 @@ namespace GraphExplorerPermissionsService.Interfaces
 {
     public interface IPermissionsStore
     {
-        string[] GetScopes(string requestUrl, string method = "GET", string scopeType = "Application");
+        string[] GetScopes(string requestUrl, string httpVerb = "GET", string scopeType = "Application");
     }
 }

--- a/GraphExplorerPermissionsService/Interfaces/IPermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionsStore.cs
@@ -6,6 +6,6 @@ namespace GraphExplorerPermissionsService.Interfaces
 {
     public interface IPermissionsStore
     {
-        string[] GetScopes(string requestUrl, string httpVerb = "GET", string scopeType = "Application");
+        string[] GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork");
     }
 }

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -91,10 +91,15 @@ namespace GraphExplorerPermissionsService
 
                 var resultValue = (JArray)_scopesTable[int.Parse(resultMatch.Key)];
 
-                string[] scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == httpVerb)
-                    .SelectToken(scopeType)
+                string[] scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == httpVerb)?
+                    .SelectToken(scopeType)?
                     .Select(s => (string)s)
                     .ToArray();
+
+                if (scopes == null || scopes.Count() == 0)
+                {
+                    return null;
+                }
 
                 return scopes;
             }

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -67,7 +67,7 @@ namespace GraphExplorerPermissionsService
         /// <param name="httpVerb">The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="scopeType">The type of scope to be retrieved for the target request url.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public string[] GetScopes(string requestUrl, string httpVerb = "GET", string scopeType = "Application")
+        public string[] GetScopes(string requestUrl, string httpVerb = "GET", string scopeType = "DelegatedWork")
         {
             if (!_scopesTable.Any())
             {

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -64,10 +64,10 @@ namespace GraphExplorerPermissionsService
         /// Retrieves the permission scopes for a given request url.
         /// </summary>
         /// <param name="requestUrl">The target request url whose scopes are to be retrieved.</param>
-        /// <param name="httpVerb">The target http verb of the request url whose scopes are to be retrieved.</param>
+        /// <param name="method">The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="scopeType">The type of scope to be retrieved for the target request url.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public string[] GetScopes(string requestUrl, string httpVerb = "GET", string scopeType = "DelegatedWork")
+        public string[] GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork")
         {
             if (!_scopesTable.Any())
             {
@@ -91,7 +91,7 @@ namespace GraphExplorerPermissionsService
 
                 var resultValue = (JArray)_scopesTable[int.Parse(resultMatch.Key)];
 
-                string[] scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == httpVerb)?
+                string[] scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == method)?
                     .SelectToken(scopeType)?
                     .Select(s => (string)s)
                     .ToArray();

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -270,6 +270,385 @@ namespace PermissionsService.Test
         }
 
         [Fact]
+        public void ReturnNullGivenANonExistentHttpVerb()
+        {
+            /* Arrange */
+
+            Mock<IFileUtility> moqFileUtility = new Mock<IFileUtility>();
+            Mock<IConfiguration> moqConfiguration = new Mock<IConfiguration>();
+            string permissionsFilePathSource = ".\\Permissions\\apiPermissionsAndScopes.json";
+
+            moqFileUtility.Setup(x => x.ReadFromFile(permissionsFilePathSource)).ReturnsAsync(() =>
+                            @"{
+                            ""ApiPermissions"": {
+                                ""/security/alerts/{alert_id}"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""PATCH"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ],
+                                ""/security/alerts"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ]
+                                }
+                            }");
+
+            moqConfiguration.Setup(a => a["Permissions:PermissionsAndScopesFilePathName"]).Returns(permissionsFilePathSource);
+
+            PermissionsStore permissionsStore = new PermissionsStore(moqFileUtility.Object, moqConfiguration.Object);
+
+            // Act
+            string[] result = permissionsStore.GetScopes("/security/alerts/{alert_id}", "Foobar"); // non-existent http verb
+
+            // Assert that returned result is null
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ReturnNullGivenANonExistentScopeType()
+        {
+            /* Arrange */
+
+            Mock<IFileUtility> moqFileUtility = new Mock<IFileUtility>();
+            Mock<IConfiguration> moqConfiguration = new Mock<IConfiguration>();
+            string permissionsFilePathSource = ".\\Permissions\\apiPermissionsAndScopes.json";
+
+            moqFileUtility.Setup(x => x.ReadFromFile(permissionsFilePathSource)).ReturnsAsync(() =>
+                            @"{
+                            ""ApiPermissions"": {
+                                ""/security/alerts/{alert_id}"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""PATCH"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ],
+                                ""/security/alerts"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ]
+                                }
+                            }");
+
+            moqConfiguration.Setup(a => a["Permissions:PermissionsAndScopesFilePathName"]).Returns(permissionsFilePathSource);
+
+            PermissionsStore permissionsStore = new PermissionsStore(moqFileUtility.Object, moqConfiguration.Object);
+
+            // Act
+            string[] result = permissionsStore.GetScopes("/security/alerts/{alert_id}", "PATCH", "Foobar"); // non-existent scope type
+
+            // Assert that returned result is null
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ReturnNullForEmptyPermissionScopesForRequestedScopeType()
+        {
+            /* Arrange */
+
+            Mock<IFileUtility> moqFileUtility = new Mock<IFileUtility>();
+            Mock<IConfiguration> moqConfiguration = new Mock<IConfiguration>();
+            string permissionsFilePathSource = ".\\Permissions\\apiPermissionsAndScopes.json";
+
+            // Empty scopes for the 'DelegatedPersonal' scope type
+            moqFileUtility.Setup(x => x.ReadFromFile(permissionsFilePathSource)).ReturnsAsync(() =>
+                            @"{
+                            ""ApiPermissions"": {
+                                ""/security/alerts/{alert_id}"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                      
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""PATCH"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ],
+                                ""/security/alerts"": [
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    },
+                                    {
+                                    ""HttpVerb"": ""GET"",
+                                    ""DelegatedWork"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ],
+                                    ""DelegatedPersonal"": [
+                                        ""Not supported.""
+                                    ],
+                                    ""Application"": [
+                                        ""SecurityEvents.Read.All"",
+                                        ""SecurityEvents.ReadWrite.All""
+                                    ]
+                                    }
+                                ]
+                                }
+                            }");
+
+            moqConfiguration.Setup(a => a["Permissions:PermissionsAndScopesFilePathName"]).Returns(permissionsFilePathSource);
+
+            PermissionsStore permissionsStore = new PermissionsStore(moqFileUtility.Object, moqConfiguration.Object);
+
+            // Act by requesting scopes for the 'DelegatedPersonal' scope type
+            string[] result = permissionsStore.GetScopes("/security/alerts/{alert_id}", "GET", "DelegatedPersonal");
+
+            // Assert that returned result is null
+            Assert.Null(result);
+        }
+
+        [Fact]
         public void ThrowInvalidOperationExceptionIfTablesNotPopulatedDueToIncorrectPermissionsFilePathName()
         {
             /* Arrange */


### PR DESCRIPTION
This PR closes #119 

Proposes:
- Adding null-conditional operators in the LINQ query that searches the permissions and scopes json object to evaluate to `null` instead of throwing `Object reference exceptions` or `ArgumentExceptions` as is the current situation in the `GetScopes` method of the `PermissionStore.cs` class. The culprit target values are `httpVerb` and `scopeType`, throwing the above exceptions respectively if missing from the json object.
- Adding an evaluation check for returned empty scopes for a given scope type. This needs to evaluate to a null return value as well. There are some permissions with empty list of scopes in the permissions and scopes json file; these need to be accounted for.
- Adding validation tests to validate the above bug fixes.


