### PR TITLE
Fix for accessing of property segments of type stream in C#

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -719,5 +719,27 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        //This test asserts that a request for a structural properties of type stream are generated in the normal url like fashion as
+        // streams have the request builders generated.
+        public void GeneratesSnippetsWithStructuralPropertiesOfTypeStream()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/v1.0/me/drive/items/{item-id}/content");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var stream = await graphClient.Me.Drive.Items[\"{item-id}\"].Content\n" +
+                                           "\t.Request()\n" +
+                                           "\t.GetAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -39,7 +39,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 if (snippetModel.Method == HttpMethod.Get)
                 {
                     var extraSnippet = "";
-                    if (segment is PropertySegment)
+                    if (segment is PropertySegment && !segment.EdmType.IsStream())//streams can be sorted out normally
                     { 
                         extraSnippet = GeneratePropertySectionSnippet(snippetModel);
                         snippetModel.SelectFieldList = snippetModel.SelectFieldList.Select(CommonGenerator.UppercaseFirstLetter).ToList();
@@ -162,8 +162,12 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     case ValueSegment _:
                         resourcesPath.Append(".Content");
                         break;
-                    case PropertySegment _:
-                        //dont append anything since this is not accessed directly in C#
+                    case PropertySegment propertySegment:
+                        //don't append anything that is not a stream since this is not accessed directly in C#
+                        if (propertySegment.EdmType.IsStream())
+                        {
+                            resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
+                        }
                         break;
                     case ReferenceSegment _:
                         resourcesPath.Append(".Reference");

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using CodeSnippetsReflection.LanguageGenerators;
 using Microsoft.OData;
 using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
@@ -74,11 +75,11 @@ namespace CodeSnippetsReflection
 
             if (edmType is IEdmNamedElement edmNamedElement)
             {
-                return edmNamedElement.Name;
+                return CommonGenerator.LowerCaseFirstLetter(edmNamedElement.Name);
             }
             
             //its not a collection/or named type so the identifier can do
-            return oDataPathSegment.Identifier;
+            return CommonGenerator.LowerCaseFirstLetter(oDataPathSegment.Identifier);
         }
 
 


### PR DESCRIPTION
This PR closes #123 

At the moment, property segments cannot be accessed directly by the .net SDK but the property segments of type Stream can. 
This PR therefore makes the snippets that involve the accessing of the structural properties of type stream to be done directly.

This PR also
- Adds a test to validate the change 
- Ensures variable names start with a lowercase letter.