### PR TITLE
Adds support for consuming and dispatching scopes information

### DIFF
--- a/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
@@ -2,10 +2,13 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using GraphExplorerPermissionsService.Models;
+using System.Collections.Generic;
+
 namespace GraphExplorerPermissionsService.Interfaces
 {
     public interface IPermissionsStore
     {
-        string[] GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork");
+        List<ScopeInformation> GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork");
     }
 }

--- a/GraphExplorerPermissionsService/Models/ScopeInformation.cs
+++ b/GraphExplorerPermissionsService/Models/ScopeInformation.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using Newtonsoft.Json;
+
+namespace GraphExplorerPermissionsService.Models
+{
+    /// <summary>
+    /// Defines a representation of a scope information.
+    /// </summary>
+    public class ScopeInformation
+    {
+        [JsonProperty(Required = Required.Always, PropertyName = "value")]
+        public string ScopeName { get; set; }
+        [JsonProperty(Required = Required.Always, PropertyName = "consentDisplayName")]
+        public string DisplayName { get; set; }
+        [JsonProperty(Required = Required.Always, PropertyName = "consentDescription")]
+        public string Description { get; set; }
+        [JsonProperty(Required = Required.Always, PropertyName = "isAdmin")]
+        public bool IsAdmin { get; set; }
+    }
+}

--- a/GraphExplorerPermissionsService/Models/ScopesInformationList.cs
+++ b/GraphExplorerPermissionsService/Models/ScopesInformationList.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace GraphExplorerPermissionsService.Models
+{
+    /// <summary>
+    /// Defines a list which holds a collection of delegated and application <see cref="ScopeInformation"/> objects.
+    /// </summary>
+    public class ScopesInformationList
+    {
+        public List<ScopeInformation> DelegatedScopesList { get; set; }
+        public List<ScopeInformation> ApplicationScopesList { get; set; }
+
+        public ScopesInformationList()
+        {
+            DelegatedScopesList = new List<ScopeInformation>();
+            ApplicationScopesList = new List<ScopeInformation>();
+        }
+    }
+}

--- a/GraphExplorerPermissionsService/Models/ScopesInformationList.cs
+++ b/GraphExplorerPermissionsService/Models/ScopesInformationList.cs
@@ -9,7 +9,7 @@ namespace GraphExplorerPermissionsService.Models
     /// <summary>
     /// Defines a list which holds a collection of delegated and application <see cref="ScopeInformation"/> objects.
     /// </summary>
-    public class ScopesInformationList
+    internal class ScopesInformationList
     {
         public List<ScopeInformation> DelegatedScopesList { get; set; }
         public List<ScopeInformation> ApplicationScopesList { get; set; }

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -65,9 +65,9 @@ namespace GraphExplorerPermissionsService
             HashSet<string> uniqueRequestUrlsTable = new HashSet<string>();
             int count = 0;
 
-            foreach (string permissionPath in _permissionsFilePaths)
+            foreach (string permissionFilePath in _permissionsFilePaths)
             {
-                string jsonString = _fileUtility.ReadFromFile(permissionPath).GetAwaiter().GetResult();
+                string jsonString = _fileUtility.ReadFromFile(permissionFilePath).GetAwaiter().GetResult();
 
                 if (!string.IsNullOrEmpty(jsonString))
                 {

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -4,7 +4,9 @@
 
 using FileService.Interfaces;
 using GraphExplorerPermissionsService.Interfaces;
+using GraphExplorerPermissionsService.Models;
 using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -17,70 +19,103 @@ namespace GraphExplorerPermissionsService
     public class PermissionsStore : IPermissionsStore
     {
         private readonly UriTemplateTable _urlTemplateTable;
-        private readonly IDictionary<int, object> _scopesTable;
+        private readonly IDictionary<int, object> _scopesListTable;
+        private readonly IDictionary<string, ScopeInformation> _delegatedScopesInfoTable;
+        private readonly IDictionary<string, ScopeInformation> _applicationScopesInfoTable;
         private readonly IFileUtility _fileUtility;
-        private readonly List<string> _permissionsFilePaths;        
+        private readonly List<string> _permissionsFilePaths;
+        private readonly string _scopesInformation;
 
         public PermissionsStore(IFileUtility fileUtility, IConfiguration configuration)
         {
-            try
-            {
-                _urlTemplateTable = new UriTemplateTable();
-                _scopesTable = new Dictionary<int, object>();
-                _fileUtility = fileUtility;
-                _permissionsFilePaths = configuration.GetSection("Permissions:FilePaths").Get<List<string>>();
+            _urlTemplateTable = new UriTemplateTable();
+            _scopesListTable = new Dictionary<int, object>();
+            _delegatedScopesInfoTable = new Dictionary<string, ScopeInformation>();
+            _applicationScopesInfoTable = new Dictionary<string, ScopeInformation>();
+            _fileUtility = fileUtility;
+            _permissionsFilePaths = configuration.GetSection("Permissions:FilePaths").Get<List<string>>();
+            _scopesInformation = configuration["Permissions:ScopesInformationList"];
 
-                SeedTables();
-            }
-            catch
-            {
-                throw;
-            }            
+            SeedTables();
         }
-
-        /// <summary>
-        /// Populates the template table with the request urls and the scopes table with the permission scopes.
-        /// </summary>
+        
         private void SeedTables()
         {
             try
             {
-                HashSet<string> uniqueRequestUrlsTable = new HashSet<string>();
-                int count = 0;
+                /* Order of seeding matters. 
+                 * Scopes info. tables are less important to us vis-à-vis the Permission tables;
+                 * In case of an exception when seeding the Scopes info. table we can safely exit 
+                 * with confidence since permissions are already seeded. */
 
-                foreach (string permissionPath in _permissionsFilePaths)
-                {
-                    string jsonString = _fileUtility.ReadFromFile(permissionPath).GetAwaiter().GetResult();
-
-                    if (!string.IsNullOrEmpty(jsonString))
-                    {
-                        JObject permissionsObject = JObject.Parse(jsonString);
-
-                        JToken apiPermissions = permissionsObject.First.First;
-                        
-                        foreach (JProperty property in apiPermissions)
-                        {
-                            // Remove any '(...)' from the request url and set to lowercase for uniformity
-                            string requestUrl = Regex.Replace(property.Name.ToLower(), @"\(.*?\)", string.Empty);
-
-                            if (uniqueRequestUrlsTable.Add(requestUrl))
-                            {
-                                count++;
-
-                                // Add the request url
-                                _urlTemplateTable.Add(count.ToString(), new UriTemplate(requestUrl));
-
-                                // Add the permission scopes
-                                _scopesTable.Add(count, property.Value);
-                            }
-                        }
-                    }
-                }
+                SeedPermissionsTables();
+                SeedScopesInfoTables();                
             }
             catch
             {
                 // Do nothing; the tables will just be empty
             }                  
+        }
+
+        /// <summary>
+        /// Populates the template table with the request urls and the scopes table with the permission scopes.
+        /// </summary>
+        private void SeedPermissionsTables()
+        {
+            HashSet<string> uniqueRequestUrlsTable = new HashSet<string>();
+            int count = 0;
+
+            foreach (string permissionPath in _permissionsFilePaths)
+            {
+                string jsonString = _fileUtility.ReadFromFile(permissionPath).GetAwaiter().GetResult();
+
+                if (!string.IsNullOrEmpty(jsonString))
+                {
+                    JObject permissionsObject = JObject.Parse(jsonString);
+
+                    JToken apiPermissions = permissionsObject.First.First;
+
+                    foreach (JProperty property in apiPermissions)
+                    {
+                        // Remove any '(...)' from the request url and set to lowercase for uniformity
+                        string requestUrl = Regex.Replace(property.Name.ToLower(), @"\(.*?\)", string.Empty);
+
+                        if (uniqueRequestUrlsTable.Add(requestUrl))
+                        {
+                            count++;
+
+                            // Add the request url
+                            _urlTemplateTable.Add(count.ToString(), new UriTemplate(requestUrl));
+
+                            // Add the permission scopes
+                            _scopesListTable.Add(count, property.Value);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Populates the delegated and application scopes information tables. 
+        /// </summary>
+        private void SeedScopesInfoTables()
+        {
+            string scopesInfoJson = _fileUtility.ReadFromFile(_scopesInformation).GetAwaiter().GetResult();
+
+            if (!string.IsNullOrEmpty(scopesInfoJson))
+            {
+                ScopesInformationList scopesInformationList = JsonConvert.DeserializeObject<ScopesInformationList>(scopesInfoJson);
+
+                foreach (ScopeInformation delegatedScopeInfo in scopesInformationList.DelegatedScopesList)
+                {
+                    _delegatedScopesInfoTable.Add(delegatedScopeInfo.ScopeName, delegatedScopeInfo);
+                }
+
+                foreach (ScopeInformation applicationScopeInfo in scopesInformationList.ApplicationScopesList)
+                {
+                    _applicationScopesInfoTable.Add(applicationScopeInfo.ScopeName, applicationScopeInfo);
+                }
+            }
         }
 
         /// <summary>
@@ -90,9 +125,9 @@ namespace GraphExplorerPermissionsService
         /// <param name="method">The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="scopeType">The type of scope to be retrieved for the target request url.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public string[] GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork")
+        public List<ScopeInformation> GetScopes(string requestUrl, string method = "GET", string scopeType = "DelegatedWork")
         {
-            if (!_scopesTable.Any())
+            if (!_scopesListTable.Any())
             {
                 throw new InvalidOperationException($"The permissions and scopes data sources are empty; " +
                     $"check the source file or check whether the file path is properly set. File path: {_permissionsFilePaths}");
@@ -115,14 +150,52 @@ namespace GraphExplorerPermissionsService
                     return null;
                 }
 
-                JArray resultValue = (JArray)_scopesTable[int.Parse(resultMatch.Key)];
+                JArray resultValue = (JArray)_scopesListTable[int.Parse(resultMatch.Key)];
 
                 string[] scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == method)?
                     .SelectToken(scopeType)?
                     .Select(s => (string)s)
                     .ToArray();
 
-                return scopes ?? null;
+                List<ScopeInformation> scopesList = null;
+
+                if (scopes != null)
+                {
+                    scopesList = new List<ScopeInformation>();
+
+                    foreach (string scopeName in scopes)
+                    {
+                        ScopeInformation scopeInfo = null;
+                        if (scopeType.Contains("Delegated"))
+                        {
+                            if (_delegatedScopesInfoTable.ContainsKey(scopeName))
+                            {
+                                scopeInfo = _delegatedScopesInfoTable[scopeName];    
+                            }                                                       
+                        }
+                        else // Application scopes
+                        {
+                            if (_applicationScopesInfoTable.ContainsKey(scopeName))
+                            {
+                                scopeInfo = _applicationScopesInfoTable[scopeName];
+                            }                                
+                        }
+                        
+                        if (scopeInfo == null)
+                        {
+                            scopesList.Add(new ScopeInformation
+                            {
+                                ScopeName = scopeName
+                            });
+                        }
+                        else
+                        {
+                            scopesList.Add(scopeInfo);
+                        }
+                    }
+                }
+
+                return scopesList ?? null;
             }
             catch (ArgumentException)
             {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -1,5 +1,11 @@
-﻿using System;
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
 using GraphExplorerPermissionsService.Interfaces;
+using GraphExplorerPermissionsService.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -23,7 +29,7 @@ namespace GraphWebApi.Controllers
         {
             try
             {
-                string[] result = null;
+                List<ScopeInformation> result = null;
 
                 result = _permissionsStore.GetScopes(requestUrl, method, scopeType);
 

--- a/GraphWebApi/Permissions/ScopesInformationList.json
+++ b/GraphWebApi/Permissions/ScopesInformationList.json
@@ -1,0 +1,1758 @@
+{
+    "delegatedScopesList":
+        [
+            {
+                "adminConsentDescription":  "Allows the app to read identity risky user information for all users in your organization on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read identity risky user information",
+                "id":  "d04bb851-cb7c-4146-97c7-ca3e71baf56c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read identity risky user information for all users in your organization on behalf of the signed-in user.",
+                "consentDisplayName":  "Read identity risky user information",
+                "value":  "identityriskyuser.read.all"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to deliver its notifications on behalf of signed-in users. Also allows the app to read, update, and delete the user's notification items for this app.",
+                "adminConsentDisplayName":  "Deliver and manage user notifications for this app",
+                "id":  "89497502-6e42-46a2-8cb2-427fd3df970a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to deliver its notifications, on your behalf. Also allows the app to read, update, and delete your notification items for this app.",
+                "consentDisplayName":  "Deliver and manage your notifications for this app",
+                "value":  "Notifications.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write your organization's conditional access policies on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write your organization's conditional access policies",
+                "id":  "ad902697-1014-4ef5-81ef-2b4301988e8c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write your organization's conditional access policies on your behalf.",
+                "consentDisplayName":  "Read and write your organization's conditional access policies",
+                "value":  "Policy.ReadWrite.ConditionalAccess"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's policies on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read your organization's policies",
+                "id":  "572fea84-0151-49b2-9301-11cb16974376",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's policies on your behalf.",
+                "consentDisplayName":  "Read your organization's policies",
+                "value":  "Policy.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read access reviews, reviewers, decisions and settings that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all access reviews that user can access",
+                "id":  "ebfcd32b-babb-40f4-a14b-42706e83bd28",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read information on access reviews, reviewers, decisions and settings that you have access to.",
+                "consentDisplayName":  "Read access reviews that you can access",
+                "value":  "AccessReview.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, update, delete and perform actions on access reviews, reviewers, decisions and settings that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Manage all access reviews that user can access",
+                "id":  "e4aa47b9-9a69-4109-82ed-36ec70d85ff1",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read, update and perform action on access reviews, reviewers, decisions and settings that you have access to.",
+                "consentDisplayName":  "Manage access reviews that you can access",
+                "value":  "AccessReview.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read programs and program controls that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all programs that user can access",
+                "id":  "c492a2e1-2f8f-4caa-b076-99bbf6e40fe4",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read information on programs and program controls that you have access to.",
+                "consentDisplayName":  "Read programs that you can access",
+                "value":  "ProgramControl.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, update, delete and perform actions on programs and program controls that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Manage all programs that user can access",
+                "id":  "50fd364f-9d93-4ae1-b170-300e87cccf84",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read, update and perform action on programs and program controls that you have access to.",
+                "consentDisplayName":  "Manage programs that you can access",
+                "value":  "ProgramControl.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete apps in the app catalogs.",
+                "adminConsentDisplayName":  "Read and write to all app catalogs",
+                "id":  "1ca167d5-1655-44a1-8adf-1414072e1ef9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to create, read, update, and delete apps in the app catalogs.",
+                "consentDisplayName":  "Read and write to all app catalogs",
+                "value":  "AppCatalog.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+                "adminConsentDisplayName":  "Export user's data",
+                "id":  "405a51b5-8d8d-430b-9842-8be4b0e9f324",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+                "consentDisplayName":  "Export user's data",
+                "value":  "User.Export.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to request and manage just in time elevation (including scheduled elevation) of users to Azure AD built-in administrative roles, on behalf of signed-in users.",
+                "adminConsentDisplayName":  "Read and write privileged access to Azure AD",
+                "id":  "3c3c74f5-cdaa-4a97-b7e0-4e788bfcfb37",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to request and manage just in time elevation (including scheduled elevation) of users to Azure AD built-in administrative roles, on your behalf.",
+                "consentDisplayName":  "Read and write privileged access to Azure AD",
+                "value":  "PrivilegedAccess.ReadWrite.AzureAD"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to request and manage time-based assignment and just-in-time elevation of user privileges to manage Azure resources (like subscriptions, resource groups, storage, compute) on behalf of the signed-in users.",
+                "adminConsentDisplayName":  "Read and write privileged access to Azure resources",
+                "id":  "a84a9652-ffd3-496e-a991-22ba5529156a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to request and manage time-based assignment and just-in-time elevation of user privileges to manage ?your Azure resources (like your subscriptions, resource groups, storage, compute) on your behalf.",
+                "consentDisplayName":  "Read and write privileged access to your Azure resources",
+                "value":  "PrivilegedAccess.ReadWrite.AzureResources"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read all webhook subscriptions on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all webhook subscriptions (preview)",
+                "id":  "5f88184c-80bb-4d52-9ff2-757288b2e9b7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read all webhook subscriptions on your behalf.",
+                "consentDisplayName":  "Read all webhook subscriptions (preview)",
+                "value":  "Subscription.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use agreements on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all terms of use agreements",
+                "id":  "af2819c9-df71-4dd3-ade7-4d7c9dc653b7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read terms of use agreements on your behalf.",
+                "consentDisplayName":  "Read all terms of use agreements",
+                "value":  "Agreement.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write terms of use agreements on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write all terms of use agreements",
+                "id":  "ef4b5d93-3104-4664-9053-a5c49ab44218",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write terms of use agreements on your behalf.",
+                "consentDisplayName":  "Read and write all terms of use agreements",
+                "value":  "Agreement.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use acceptance statuses on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user terms of use acceptance statuses",
+                "id":  "0b7643bb-5336-476f-80b5-18fbfbc91806",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your terms of use acceptance statuses.",
+                "consentDisplayName":  "Read your terms of use acceptance statuses",
+                "value":  "AgreementAcceptance.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use acceptance statuses on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read terms of use acceptance statuses that user can access",
+                "id":  "a66a5341-e66e-4897-9d52-c2df58c2bfb9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read terms of use acceptance statuses on your behalf.",
+                "consentDisplayName":  "Read all terms of use acceptance statuses",
+                "value":  "AgreementAcceptance.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and query your audit log activities, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read audit log data",
+                "id":  "e4c9e354-4dc5-45b8-9e7c-e1393b0b1a20",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and query your audit log activities, on your behalf.",
+                "consentDisplayName":  "Read audit log data",
+                "value":  "AuditLog.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and report the signed-in user's activity in the app.",
+                "adminConsentDisplayName":  "Read and write app activity to users' activity feed",
+                "id":  "47607519-5fb1-47d9-99c7-da4b48f369b1",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read and report your activity in the app.",
+                "consentDisplayName":  "Read and write app activity to your activity feed",
+                "value":  "UserActivity.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "adminConsentDisplayName":  "Read Microsoft Intune Device Configuration and Policies",
+                "id":  "f1493658-876a-4c87-8fa7-edb559b3476a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "consentDisplayName":  "Read Microsoft Intune Device Configuration and Policies",
+                "value":  "DeviceManagementConfiguration.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune Device Configuration and Policies",
+                "id":  "0883f392-0a7a-443d-8c76-16a6d39c7b63",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "consentDisplayName":  "Read and write Microsoft Intune Device Configuration and Policies",
+                "value":  "DeviceManagementConfiguration.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read Microsoft Intune apps",
+                "id":  "4edf5f54-4666-44af-9de9-0144fb4b6e8c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "consentDisplayName":  "Read Microsoft Intune apps",
+                "value":  "DeviceManagementApps.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune apps",
+                "id":  "7b3f05d5-f68c-4b8d-8c59-a2ecd12f24af",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "consentDisplayName":  "Read and write Microsoft Intune apps",
+                "value":  "DeviceManagementApps.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "adminConsentDisplayName":  "Read Microsoft Intune RBAC settings",
+                "id":  "49f0cc30-024c-4dfd-ab3e-82e137ee5431",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "consentDisplayName":  "Read Microsoft Intune RBAC settings",
+                "value":  "DeviceManagementRBAC.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune RBAC settings",
+                "id":  "0c5e8a55-87a6-4556-93ab-adc52c4d862d",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "consentDisplayName":  "Read and write Microsoft Intune RBAC settings",
+                "value":  "DeviceManagementRBAC.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties of devices managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read Microsoft Intune devices",
+                "id":  "314874da-47d6-4978-88dc-cf0d37f0bb82",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties of devices managed by Microsoft Intune.",
+                "consentDisplayName":  "Read devices Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties of devices managed by Microsoft Intune. Does not allow high impact operations such as remote wipe and password reset on the device's owner.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune devices",
+                "id":  "44642bfe-8385-4adc-8fc6-fe3cb2c375c3",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties of devices managed by Microsoft Intune. Does not allow high impact operations such as remote wipe and password reset on the device's owner.",
+                "consentDisplayName":  "Read and write Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to perform remote high impact actions such as wiping the device or resetting the passcode on devices managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Perform user-impacting remote actions on Microsoft Intune devices",
+                "id":  "3404d2bf-2b13-457e-a330-c24615765193",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to perform remote high impact actions such as wiping the device or resetting the passcode on devices managed by Microsoft Intune.",
+                "consentDisplayName":  "Perform user-impacting remote actions on Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.PrivilegedOperations.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune configuration",
+                "id":  "662ed50a-ac44-4eef-ad86-62eed9be2a29",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "consentDisplayName":  "Read and write Microsoft Intune configuration",
+                "value":  "DeviceManagementServiceConfig.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "adminConsentDisplayName":  "Read Microsoft Intune configuration",
+                "id":  "8696daa5-bce5-4b2e-83f9-51b6defc4e1e",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "consentDisplayName":  "Read Microsoft Intune configuration",
+                "value":  "DeviceManagementServiceConfig.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's security events on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read your organization's security events",
+                "id":  "64733abd-851e-478a-bffb-e47a14b18235",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's security events on your behalf.",
+                "consentDisplayName":  "Read your organization's security events",
+                "value":  "SecurityEvents.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's security events on behalf of the signed-in user. Also allows the app to update editable properties in security events on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and update your organization's security events",
+                "id":  "6aedf524-7e1c-45a7-bd76-ded8cab8d0fc",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's security events on your behalf. Also allows you to update editable properties in security events.",
+                "consentDisplayName":  "Read and update your organization's security events",
+                "value":  "SecurityEvents.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a scored list of relevant people of the signed-in user or other users in the signed-in user's organization. The list can include local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "adminConsentDisplayName":  "Read all users' relevant people lists",
+                "id":  "b89f9189-71a5-4e70-b041-9887f0bc7e4a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read a list of people in the order that is most relevant to you. Allows the app to read a list of people in the order that is most relevant to another user in your organization. These can include local contacts, contacts from social networking, people listed in your organization's directory, and people from recent communications.",
+                "consentDisplayName":  "Read all users? relevant people lists",
+                "value":  "People.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Manage the state and settings of all Microsoft education apps on behalf of the user.",
+                "adminConsentDisplayName":  "Manage education app settings",
+                "id":  "63589852-04e3-46b4-bae9-15d5b1050748",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to manage the state and settings of all Microsoft education apps on your behalf.",
+                "consentDisplayName":  "Manage your education app settings",
+                "value":  "EduAdministration.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Read the state and settings of all Microsoft education apps on behalf of the user.",
+                "adminConsentDisplayName":  "Read education app settings",
+                "id":  "8523895c-6081-45bf-8a5d-f062a2f12c9f",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view the state and settings of all Microsoft education apps on your behalf.",
+                "consentDisplayName":  "View your education app settings",
+                "value":  "EduAdministration.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write assignments and their grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' class assignments and their grades",
+                "id":  "2f233e90-164b-4501-8bce-31af2559a2d3",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify your assignments on your behalf including ?grades.",
+                "consentDisplayName":  "View and modify your assignments and grades",
+                "value":  "EduAssignments.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read assignments and their grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' class assignments and their grades",
+                "id":  "091460c9-9c4a-49b2-81ef-1f3d852acce2",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view your assignments on your behalf including grades.",
+                "consentDisplayName":  "View your assignments and grades",
+                "value":  "EduAssignments.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write assignments without grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' class assignments without grades",
+                "id":  "2ef770a1-622a-47c4-93ee-28d6adbed3a0",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify your assignments on your behalf without seeing grades.",
+                "consentDisplayName":  "View and modify your assignments without grades",
+                "value":  "EduAssignments.ReadWriteBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read assignments without grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' class assignments without grades",
+                "id":  "c0b0103b-c053-4b2e-9973-9f3a544ec9b8",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view your assignments on your behalf without seeing grades.",
+                "consentDisplayName":  "View your assignments without grades",
+                "value":  "EduAssignments.ReadBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the structure of schools and classes in an organization's roster and education-specific information about users to be read and written on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' view of the roster",
+                "id":  "359e19a6-e3fa-4d7f-bcab-d28ec592b51e",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify information about schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View and modify your school, class and user information",
+                "value":  "EduRoster.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the structure of schools and classes in an organization's roster and education-specific information about users to be read on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' view of the roster",
+                "id":  "a4389601-22d9-4096-ac18-36a927199112",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view information about schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View your school, class and user information",
+                "value":  "EduRoster.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a limited subset of the properties from the structure of schools and classes in an organization's roster and a limited subset of properties about users to be read on behalf of the user.?Includes name, status, education role, email address and photo.",
+                "adminConsentDisplayName":  "Read a limited subset of users' view of the roster",
+                "id":  "5d186531-d1bf-4f07-8cea-7c42119e1bd9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view minimal ?information about both schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View a limited subset of your school, class and user information",
+                "value":  "EduRoster.ReadBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to report the signed-in user's app activity information to Microsoft Timeline.",
+                "adminConsentDisplayName":  "Write app activity to users' timeline",
+                "id":  "367492fc-594d-4972-a9b5-0d58c622c91c",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to report your app activity information to Microsoft Timeline.",
+                "consentDisplayName":  "Write app activity to your timeline",
+                "value":  "UserTimelineActivity.Write.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete user's mailbox settings. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read and write user mailbox settings",
+                "id":  "818c620a-27a9-40bd-a6a5-d96f7d610b4b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete your mailbox settings.",
+                "consentDisplayName":  "Read and write to your mailbox settings",
+                "value":  "MailboxSettings.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to launch another app or communicate with another app on a user's device on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Communicate with user devices",
+                "id":  "bac3b9c2-b516-4ef4-bd3b-c2ef73d8d804",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to launch another app or communicate with another app on a device that you own.",
+                "consentDisplayName":  "Communicate with your other devices",
+                "value":  "Device.Command"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a user's list of devices on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user devices",
+                "id":  "11d4cd79-5ba5-460f-803f-e22c8ab85ccd",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see your list of devices.",
+                "consentDisplayName":  "View your list of devices",
+                "value":  "Device.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, share, and modify OneNote notebooks that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read and write all OneNote notebooks that user can access",
+                "id":  "64ac0503-b4fa-45d9-b544-71a463f05da0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, share, and modify all the OneNote notebooks that you have access to.",
+                "consentDisplayName":  "Read and write all OneNote notebooks that you can access",
+                "value":  "Notes.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read OneNote notebooks that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all OneNote notebooks that user can access",
+                "id":  "dfabfca6-ee36-4db2-8208-7a28381419b3",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read all the OneNote notebooks that you have access to.",
+                "consentDisplayName":  "Read all OneNote notebooks that you can access",
+                "value":  "Notes.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, share, and modify OneNote notebooks on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write user OneNote notebooks",
+                "id":  "615e26af-c38a-4150-ae3e-c3b0d4cb1d6a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, share, and modify OneNote notebooks on your behalf.",
+                "consentDisplayName":  "Read and write your OneNote notebooks",
+                "value":  "Notes.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read OneNote notebooks on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user OneNote notebooks",
+                "id":  "371361e4-b9e2-4a3f-8315-2a301a3b0a3d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read OneNote notebooks on your behalf.",
+                "consentDisplayName":  "Read your OneNote notebooks",
+                "value":  "Notes.Read"
+            },
+            {
+                "adminConsentDescription":  "This is deprecated!  Do not use! This permission no longer has any effect. You can safely consent to it. No additional privileges will be granted to the app.",
+                "adminConsentDisplayName":  "Limited notebook access (deprecated)",
+                "id":  "ed68249d-017c-4df5-9113-e684c7f8760b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "This permission no longer has any effect. You can safely consent to it. No additional privileges will be granted to the app.",
+                "consentDisplayName":  "Limited access to your OneNote notebooks for this app (preview)",
+                "value":  "Notes.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the titles of OneNote notebooks and sections and to create new pages, notebooks, and sections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Create user OneNote notebooks",
+                "id":  "9d822255-d64d-4b7a-afdb-833b9a97ed02",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to view the titles of your OneNote notebooks and sections and to create new pages, notebooks, and sections on your behalf.",
+                "consentDisplayName":  "Create your OneNote notebooks",
+                "value":  "Notes.Create"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Invite guest users to the organization",
+                "id":  "63dd7cd9-b489-4adf-a28c-ac38b9a0f962",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to invite guest users to the organization, on your behalf.",
+                "consentDisplayName":  "Invite guest users to the organization",
+                "value":  "User.Invite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to the read user's mailbox settings. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read user mailbox settings",
+                "id":  "87f447af-9fa4-4c32-9dfa-4a57a73d18ce",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your mailbox settings.",
+                "consentDisplayName":  "Read your mailbox settings",
+                "value":  "MailboxSettings.Read"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read files that the user selects. The app has access for several hours after the user selects a file.",
+                "adminConsentDisplayName":  "Read files that the user selects (preview)",
+                "id":  "5447fe39-cb82-4c1a-b977-520e67e724eb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read files that you select. After you select a file, the app has access to the file for several hours.",
+                "consentDisplayName":  "Read selected files",
+                "value":  "Files.Read.Selected"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read and write files that the user selects. The app has access for several hours after the user selects a file.",
+                "adminConsentDisplayName":  "Read and write files that the user selects (preview)",
+                "id":  "17dde5bd-8c17-420f-a486-969730c1b827",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read and write files that you select. After you select a file, the app has access to the file for several hours.",
+                "consentDisplayName":  "Read and write selected files",
+                "value":  "Files.ReadWrite.Selected"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read, create, update and delete files in the application's folder.",
+                "adminConsentDisplayName":  "Have full access to the application's folder (preview)",
+                "id":  "8019c312-3263-48e6-825e-2b833497195b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read, create, update and delete files in the application's folder.",
+                "consentDisplayName":  "Have full access to the application's folder",
+                "value":  "Files.ReadWrite.AppFolder"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read all service usage reports on behalf of the signed-in user.  Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "adminConsentDisplayName":  "Read all usage reports",
+                "id":  "02e97553-ed7b-43d0-ab3c-f8bace0d040c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows an app to read all service usage reports on your behalf. Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "consentDisplayName":  "Read all usage reports",
+                "value":  "Reports.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to edit or delete documents and list items in all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Edit or delete items in all site collections",
+                "id":  "89fe6a52-be36-487e-b7d8-d061c450a026",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to edit or delete documents and list items in all site collections on your behalf.",
+                "consentDisplayName":  "Edit or delete items in all site collections",
+                "value":  "Sites.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete tasks a user has permissions to, including their own and shared tasks.",
+                "adminConsentDisplayName":  "Read and write user and shared tasks",
+                "id":  "c5ddf11b-c114-4886-8558-8a4e557cd52b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete tasks you have permissions to access, including your own and shared tasks.",
+                "consentDisplayName":  "Read and write to your and shared tasks",
+                "value":  "Tasks.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read tasks a user has permissions to access, including their own and shared tasks.",
+                "adminConsentDisplayName":  "Read user and shared tasks",
+                "id":  "88d21fd4-8e5a-4c32-b5e2-4a1c95f34f72",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read tasks you have permissions to access, including your own and shared tasks.",
+                "consentDisplayName":  "Read your and shared tasks",
+                "value":  "Tasks.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete contacts a user has permissions to, including their own and shared contacts.",
+                "adminConsentDisplayName":  "Read and write user and shared contacts",
+                "id":  "afb6c84b-06be-49af-80bb-8f3f77004eab",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete contacts you have permissions to access, including your own and shared contacts.",
+                "consentDisplayName":  "Read and write to your and shared contacts",
+                "value":  "Contacts.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read contacts a user has permissions to access, including their own and shared contacts.",
+                "adminConsentDisplayName":  "Read user and shared contacts",
+                "id":  "242b9d9e-ed24-4d09-9a52-f43769beb9d4",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read contacts you have permissions to access, including your own and shared contacts.",
+                "consentDisplayName":  "Read your and shared contacts",
+                "value":  "Contacts.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update and delete events in all calendars in the organization user has permissions to access. This includes delegate and shared calendars.",
+                "adminConsentDisplayName":  "Read and write user and shared calendars",
+                "id":  "12466101-c9b8-439a-8589-dd09ee67e8e9",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete events in all calendars in your organization you have permissions to access. This includes delegate and shared calendars.",
+                "consentDisplayName":  "Read and write to your and shared calendars",
+                "value":  "Calendars.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read events in all calendars that the user can access, including delegate and shared calendars.",
+                "adminConsentDisplayName":  "Read user and shared calendars",
+                "id":  "2b9c4092-424d-4249-948d-b43879977640",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read events in all calendars that you can access, including delegate and shared calendars.?",
+                "consentDisplayName":  "Read calendars?you can access",
+                "value":  "Calendars.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to send mail as the signed-in user, including sending on-behalf of others.",
+                "adminConsentDisplayName":  "Send mail on behalf of others",
+                "id":  "a367ab51-6b49-43bf-a716-a1fb06d2a174",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to send mail as you or on-behalf of someone else.",
+                "consentDisplayName":  "Send mail on behalf of others or yourself",
+                "value":  "Mail.Send.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete mail a user has permission to access, including their own and shared mail. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read and write user and shared mail",
+                "id":  "5df07973-7d5d-46ed-9847-1271055cbd51",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete mail you have permission to access, including your own and shared mail. Does not allow the app to send mail on your behalf.",
+                "consentDisplayName":  "Read and write mail?you can access",
+                "value":  "Mail.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read mail a user can access, including their own and shared mail.",
+                "adminConsentDisplayName":  "Read user and shared mail",
+                "id":  "7b9103a5-4610-446b-9670-80643382c1fa",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read mail you can access, including shared mail.",
+                "consentDisplayName":  "Read mail you can access",
+                "value":  "Mail.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+                "adminConsentDisplayName":  "Sign in and read user profile",
+                "id":  "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+                "consentDisplayName":  "Sign you in and read your profile",
+                "value":  "User.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+                "adminConsentDisplayName":  "Read and write access to user profile",
+                "id":  "b4e74841-8e56-480b-be8b-910348b18b4c",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+                "consentDisplayName":  "Read and update your profile",
+                "value":  "User.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+                "adminConsentDisplayName":  "Read all users' basic profiles",
+                "id":  "b340eb25-3456-403f-be2f-af7a0d370277",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+                "consentDisplayName":  "Read all users' basic profiles",
+                "value":  "User.ReadBasic.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all users' full profiles",
+                "id":  "a154be20-db9c-4678-8ab7-66f6cc099a59",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+                "consentDisplayName":  "Read all users' full profiles",
+                "value":  "User.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write all users' full profiles",
+                "id":  "204e0828-b5ca-4ad8-b9f3-f32a958e7cc4",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+                "consentDisplayName":  "Read and write all users' full profiles",
+                "value":  "User.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to list groups, and to read their properties and all group memberships on behalf of the signed-in user.  Also allows the app to read calendar, conversations, files, and other group content for all groups the signed-in user can access. ",
+                "adminConsentDisplayName":  "Read all groups",
+                "id":  "5f8c59db-677d-491f-a6b8-5f174b11ec1d",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to list groups, and to read their properties and all group memberships on your behalf.  Also allows the app to read calendar, conversations, files, and other group content for all groups you can access.  ",
+                "consentDisplayName":  "Read all groups",
+                "value":  "Group.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create groups and read all group properties and memberships on behalf of the signed-in user.  Additionally allows group owners to manage their groups and allows group members to update group content.",
+                "adminConsentDisplayName":  "Read and write all groups",
+                "id":  "4e46008b-f24c-477d-8fff-7bb4ec7aafe0",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to create groups and read all group properties and memberships on your behalf.  Additionally allows the app to manage your groups and to update group content for groups you are a member of.",
+                "consentDisplayName":  "Read and write all groups",
+                "value":  "Group.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read data in your organization's directory, such as users, groups and apps.",
+                "adminConsentDisplayName":  "Read directory data",
+                "id":  "06da0dbc-49e2-44d2-8312-53f166ab848a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read data in your organization's directory.",
+                "consentDisplayName":  "Read directory data",
+                "value":  "Directory.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write data in your organization's directory, such as users, and groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+                "adminConsentDisplayName":  "Read and write directory data",
+                "id":  "c5366453-9fb0-48a5-a156-24f0c49a4b84",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write data in your organization's directory, such as other users, groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+                "consentDisplayName":  "Read and write directory data",
+                "value":  "Directory.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to have the same access to information in the directory as the signed-in user.",
+                "adminConsentDisplayName":  "Access directory as the signed in user",
+                "id":  "0e263e50-5827-48a4-b97c-d940288653c7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to have the same access to information in your work or school directory as you do.",
+                "consentDisplayName":  "Access the directory as you",
+                "value":  "Directory.AccessAsUser.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read email in user mailboxes. ",
+                "adminConsentDisplayName":  "Read user mail ",
+                "id":  "570282fd-fa5c-430d-a7fd-fc8dc98a9dca",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read email in your mailbox. ",
+                "consentDisplayName":  "Read your mail ",
+                "value":  "Mail.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete email in user mailboxes. Does not include permission to send mail. ",
+                "adminConsentDisplayName":  "Read and write access to user mail ",
+                "id":  "024d486e-b451-40bb-833d-3e66d98c5c73",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete email in your mailbox. Does not include permission to send mail. ",
+                "consentDisplayName":  "Read and write access to your mail ",
+                "value":  "Mail.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to send mail as users in the organization. ",
+                "adminConsentDisplayName":  "Send mail as a user ",
+                "id":  "e383f46e-2787-4529-855e-0e479a3ffac0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to send mail as you. ",
+                "consentDisplayName":  "Send mail as you ",
+                "value":  "Mail.Send"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read events in user calendars . ",
+                "adminConsentDisplayName":  "Read user calendars ",
+                "id":  "465a38f9-76ea-45b9-9f34-9e8b0d4b0b42",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read events in your calendars. ",
+                "consentDisplayName":  "Read your calendars ",
+                "value":  "Calendars.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete events in user calendars. ",
+                "adminConsentDisplayName":  "Have full access to user calendars ",
+                "id":  "1ec239c2-d7c9-4623-a91a-a9775856bb36",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete events in your calendars. ",
+                "consentDisplayName":  "Have full access to your calendars  ",
+                "value":  "Calendars.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read user contacts.  ",
+                "adminConsentDisplayName":  "Read user contacts ",
+                "id":  "ff74d97f-43af-4b68-9f2a-b77ee6968c5d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read contacts in your contact folders. ",
+                "consentDisplayName":  "Read your contacts ",
+                "value":  "Contacts.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete user contacts. ",
+                "adminConsentDisplayName":  "Have full access to user contacts ",
+                "id":  "d56682ec-c09e-4743-aaf4-1a3aac4caa21",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete contacts in your contact folders. ",
+                "consentDisplayName":  "Have full access of your contacts ",
+                "value":  "Contacts.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the signed-in user's files.",
+                "adminConsentDisplayName":  "Read user files",
+                "id":  "10465720-29dd-4523-a11a-6a75c743c9d9",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your files.",
+                "consentDisplayName":  "Read your files",
+                "value":  "Files.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, create, update and delete the signed-in user's files.",
+                "adminConsentDisplayName":  "Have full access to user files",
+                "id":  "5c28f0bf-8a70-41f1-8ab2-9032436ddb65",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, create, update, and delete your files.",
+                "consentDisplayName":  "Have full access to your files",
+                "value":  "Files.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read all files the signed-in user can access.",
+                "adminConsentDisplayName":  "Read all files that user can access",
+                "id":  "df85f4d6-205c-4ac5-a5ea-6bf408dba283",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read all files you can access.",
+                "consentDisplayName":  "Read all files that you have access to",
+                "value":  "Files.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, create, update and delete all files the signed-in user can access.",
+                "adminConsentDisplayName":  "Have full access to all files user can access",
+                "id":  "863451e7-0667-486c-a5d6-d135439485f0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, create, update and delete all files that you can access.",
+                "consentDisplayName":  "Have full access to all files you have access to",
+                "value":  "Files.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to read documents and list  items in all site collections on behalf of the signed-in user",
+                "adminConsentDisplayName":  "Read items in all site collections",
+                "id":  "205e70e5-aba6-4c52-a976-6d2d46c48043",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to read documents and list items in all site collections on your behalf",
+                "consentDisplayName":  "Read items in all site collections",
+                "value":  "Sites.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows users to sign in to the app with their work or school accounts and allows the app to see basic user profile information.",
+                "adminConsentDisplayName":  "Sign users in",
+                "id":  "37f7f235-527c-4136-accd-4a02d197296e",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows you to sign in to the app with your work or school account and allows the app to read your basic profile information.",
+                "consentDisplayName":  "Sign in as you",
+                "value":  "openid"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and update user data, even when they are not currently using the app.",
+                "adminConsentDisplayName":  "Access user's data anytime",
+                "id":  "7427e0e9-2fba-42fe-b0c0-848c9e6a8182",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see and update your data, even when you are not currently using the app.",
+                "consentDisplayName":  "Access your data anytime",
+                "value":  "offline_access"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read user tasks",
+                "adminConsentDisplayName":  "Read user tasks",
+                "id":  "f45671fb-e0fe-4b4b-be20-3d3ce43f1bcb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your tasks",
+                "consentDisplayName":  "Read your tasks",
+                "value":  "Tasks.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your users' primary email address",
+                "adminConsentDisplayName":  "View users' email address",
+                "id":  "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your primary email address",
+                "consentDisplayName":  "View your email address",
+                "value":  "email"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to see your users' basic profile (name, picture, user name)",
+                "adminConsentDisplayName":  "View users' basic profile",
+                "id":  "14dad69e-099b-42c9-810b-d002981feec1",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see your basic profile (name, picture, user name)",
+                "consentDisplayName":  "View your basic profile",
+                "value":  "profile"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read identity risk event information for all users in your organization on behalf of the signed-in user. ",
+                "adminConsentDisplayName":  "Read identity risk event information",
+                "id":  "8f6a01e7-0391-4ee5-aa22-a3af122cef27",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read identity risk event information for all users in your organization on behalf of the signed-in user. ",
+                "consentDisplayName":  "Read identity risk event information",
+                "value":  "IdentityRiskEvent.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the memberships of hidden groups and administrative units on behalf of the signed-in user, for those hidden groups and administrative units that the signed-in user has access to.",
+                "adminConsentDisplayName":  "Read hidden memberships",
+                "id":  "f6a3db3e-f7e8-4ed2-a414-557c8c9830be",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the memberships of hidden groups or administrative units on your behalf, for those hidden groups or adminstrative units that you have access to.",
+                "consentDisplayName":  "Read your hidden memberships",
+                "value":  "Member.Read.Hidden"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update and delete tasks and plans (and tasks in them), that are assigned to or shared with the signed-in user.",
+                "adminConsentDisplayName":  "Create, read, update and delete user tasks and projects",
+                "id":  "2219042f-cab5-40cc-b0d2-16b1540b4c5f",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to create, read, update and delete tasks assigned to you and plans (and tasks in them) shared with or owned by you.",
+                "consentDisplayName":  "Create, read, update and delete your tasks and projects",
+                "value":  "Tasks.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a ranked list of relevant people of the signed-in user. The list includes local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "adminConsentDisplayName":  "Read users' relevant people lists",
+                "id":  "ba47897c-39ec-4d83-8086-ee8256fa737d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read a list of people in the order that's most relevant to you. This includes your local contacts, your contacts from social networking, people listed in your organization's directory, and people from recent communications.",
+                "consentDisplayName":  "Read your relevant people list",
+                "value":  "People.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to create or delete document libraries and lists in all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Create, edit, and delete items and lists in all site collections",
+                "id":  "65e50fdc-43b7-4915-933e-e8138f11f40a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to create or delete document libraries and lists in all site collections on your behalf.",
+                "consentDisplayName":  "Create, edit, and delete items and lists in all your site collections",
+                "value":  "Sites.Manage.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to have full control of all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Have full control of all site collections",
+                "id":  "5a54b8b3-347c-476d-8f8e-42d5c7424d29",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allow the application to have full control of all site collections on your behalf.",
+                "consentDisplayName":  "Have full control of all your site collections",
+                "value":  "Sites.FullControl.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write your organization's identity (authentication) providers? properties on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write identity providers",
+                "id":  "f13ce604-1677-429f-90bd-8a10b9f01325",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write your organization's identity (authentication) providers? properties on your behalf.",
+                "consentDisplayName":  "Read and write identity providers",
+                "value":  "IdentityProvider.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's identity (authentication) providers? properties on behalf of the user.",
+                "adminConsentDisplayName":  "Read identity providers",
+                "id":  "43781733-b5a7-4d1b-98f4-e8edff23e1a9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's identity (authentication) providers? properties on your behalf.",
+                "consentDisplayName":  "Read identity providers",
+                "value":  "IdentityProvider.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read bookings information",
+                "id":  "33b1df99-4b29-4548-9339-7a7b83eaeebc",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read bookings appointments, businesses, customers, services, and staff on your behalf.",
+                "consentDisplayName":  "Read bookings information",
+                "value":  "Bookings.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read and write bookings appointments and customers, and additionally allows read businesses information, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write booking appointments",
+                "id":  "02a5a114-36a6-46ff-a102-954d89d9ab02",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read and write bookings appointments and customers, and additionally allows read businesses information, services, and staff on your behalf.",
+                "consentDisplayName":  "Read and write booking appointments",
+                "value":  "BookingsAppointment.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read and write bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user. Does not allow create, delete and publish of booking businesses.",
+                "adminConsentDisplayName":  "Read and write bookings information",
+                "id":  "948eb538-f19d-4ec5-9ccc-f059e1ea4c72",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read and write Bookings appointments, businesses, customers, services, and staff on your behalf. Does not allow create, delete and publish of booking businesses.",
+                "consentDisplayName":  "Read and write bookings information",
+                "value":  "Bookings.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read, write and manage bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Manage bookings information",
+                "id":  "7f36b48e-542f-4d3b-9bcb-8406f0ab9fdb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read, write and manage bookings appointments, businesses, customers, services, and staff on your behalf.",
+                "consentDisplayName":  "Manage bookings information",
+                "value":  "Bookings.Manage.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to have the same access to mailboxes as the signed-in user via Exchange ActiveSync.",
+                "adminConsentDisplayName":  "Access mailboxes via Exchange ActiveSync",
+                "id":  "ff91d191-45a0-43fd-b837-bd682c4a0b0f",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app full access to your mailboxes on your behalf.",
+                "consentDisplayName":  "Access your mailboxes",
+                "value":  "EAS.AccessAsUser.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write financials data on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write financials data",
+                "id":  "f534bf13-55d4-45a9-8f3c-c92fe64d6131",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read and write financials data on your behalf.",
+                "consentDisplayName":  "Read and write financials data",
+                "value":  "Financials.ReadWrite.All"
+            }
+        ],
+    "applicationScopesList":
+        [
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, update, delete and perform actions on programs and program controls in the organization, without a signed-in user.",
+                "consentDisplayName":  "Manage all programs",
+                "id":  "60a901ed-09f7-4aa5-a16e-7dd3d6f9de36",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ProgramControl.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read programs and program controls in the organization, without a signed-in user.",
+                "consentDisplayName":  "Read all programs",
+                "id":  "eedb7fdd-7539-4345-a38b-4839e4a84cbd",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ProgramControl.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, update, delete and perform actions on access reviews, reviewers, decisions and settings in the organization, without a signed-in user.",
+                "consentDisplayName":  "Manage all access reviews",
+                "id":  "ef5f7d5c-338f-44b0-86c3-351f46c8bb5f",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AccessReview.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read access reviews, reviewers, decisions and settings in the organization, without a signed-in user.",
+                "consentDisplayName":  "Read all access reviews",
+                "id":  "d07a8cc0-3d51-4b77-b3b0-32704d1f69fa",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AccessReview.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the identity risky user information for your organization without a signed in user.",
+                "consentDisplayName":  "Read all identity risky user information",
+                "id":  "dc5007c0-2d7d-4c42-879c-2dab87571379",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "identityriskyuser.read.all"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and create online meetings as an application in your organization.",
+                "consentDisplayName":  "Read and create online meetings (preview)",
+                "id":  "b8bb2037-6e08-44ac-a4ea-4674e010e2a4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "OnlineMeetings.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows an app to read all service usage reports without a signed-in user.  Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "consentDisplayName":  "Read all usage reports",
+                "id":  "230c1aed-a721-4c5d-9cb4-a90514e508ef",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Reports.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read any user's scored list of relevant people, without a signed-in user. The list can include local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "consentDisplayName":  "Read all users' relevant people lists",
+                "id":  "b528084d-ad10-4598-8b93-929746b4d7d6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "People.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to update Microsoft Teams 1-to-1 or group chat messages by patching a set of Data Loss Prevention (DLP) policy violation properties to handle the output of DLP processing.",
+                "consentDisplayName":  "Flag chat messages for violating policy",
+                "id":  "7e847308-e030-4183-9899-5235d7270f58",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Chat.UpdatePolicyViolation.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all 1-to-1 or group chat messages in Microsoft Teams.",
+                "consentDisplayName":  "Read all chat messages",
+                "id":  "6b7d71aa-70aa-4810-a8d9-5d9fb2830017",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Chat.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all channel messages in Microsoft Teams",
+                "consentDisplayName":  "Read all channel messages",
+                "id":  "7b2449af-6ccd-4f4d-9f78-e550c193f0d1",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ChannelMessage.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to update Microsoft Teams channel messages by patching a set of Data Loss Prevention (DLP) policy violation properties to handle the output of DLP processing.",
+                "consentDisplayName":  "Flag channel messages for violating policy",
+                "id":  "4d02b0cc-d90b-441f-8d82-4fb55c34d6bb",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ChannelMessage.UpdatePolicyViolation.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update and delete applications and service principals without a signed-in user.  Does not allow management of consent grants.",
+                "consentDisplayName":  "Read and write all applications",
+                "id":  "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Application.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create other applications, and fully manage those applications (read, update, update application secrets and delete), without a signed-in user. ?It cannot update any apps that it is not an owner of.",
+                "consentDisplayName":  "Manage apps that this app creates or owns",
+                "id":  "18a4783c-866b-4cc7-a460-3d5e5662c884",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Application.ReadWrite.OwnedBy"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read online meeting details in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read online meeting details (preview)",
+                "id":  "c1684f21-1984-47fa-9d61-2dc8c296bb70",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "OnlineMeetings.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to get direct access to media streams in a call, without a signed-in user.",
+                "consentDisplayName":  "Access media streams in a call as an app (preview)",
+                "id":  "a7a681dc-756e-4909-b988-f160edc6655f",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.AccessMedia.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to anonymously join group calls and scheduled meetings in your organization, without a signed-in user. ?The app will be joined as a guest to meetings in your organization.",
+                "consentDisplayName":  "Join group calls and meetings as a guest (preview)",
+                "id":  "fd7ccf6b-3d28-418b-9701-cd10f5cd2fd4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.JoinGroupCallAsGuest.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to join group calls and scheduled meetings in your organization, without a signed-in user. ?The app will be joined with the privileges of a directory user to meetings in your organization.",
+                "consentDisplayName":  "Join group calls and meetings as an app (preview)",
+                "id":  "f6b49018-60ab-4f81-83bd-22caeabfed2d",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.JoinGroupCall.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to place outbound calls to multiple users and add participants to meetings in your organization, without a signed-in user.",
+                "consentDisplayName":  "Initiate outgoing group calls from the app (preview)",
+                "id":  "4c277553-8a09-487b-8023-29ee378d8324",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.InitiateGroupCall.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to place outbound calls to a single user and transfer calls to users in your organization's directory, without a signed-in user.",
+                "consentDisplayName":  "Initiate outgoing 1:1 calls from the app (preview)",
+                "id":  "284383ee-7f6e-4e40-a2a8-e85dcb029101",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.Initiate.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and query your audit log activities, without a signed-in user.",
+                "consentDisplayName":  "Read all audit log data",
+                "id":  "b0afded3-3588-46d8-8b3d-9842eff778da",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AuditLog.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read your organization's security events without a signed-in user.",
+                "consentDisplayName":  "Read your organization's security events",
+                "id":  "bf394140-e372-4bf9-a898-299cfc7564e5",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "SecurityEvents.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read your organization's security events without a signed-in user. Also allows the app to update editable properties in security events.",
+                "consentDisplayName":  "Read and update your organization's security events",
+                "id":  "d903a879-88e0-4c09-b0c9-82f6a1333f84",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "SecurityEvents.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete documents and list items in all site collections without a signed in user.",
+                "consentDisplayName":  "Read and write items in all site collections (preview)",
+                "id":  "9492366f-7969-46a4-8d15-ed1a20078fff",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read documents and list items in all site collections without a signed in user.",
+                "consentDisplayName":  "Read items in all site collections (preview)",
+                "id":  "332a536c-c7ef-4017-ab91-336970924f0d",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Manage the state and settings of all Microsoft education apps.",
+                "consentDisplayName":  "Manage education app settings",
+                "id":  "9bc431c3-b8bc-4a8d-a219-40f10f92eff6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAdministration.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Read the state and settings of all Microsoft education apps.",
+                "consentDisplayName":  "Read Education app settings",
+                "id":  "7c9db06a-ec2d-4e7b-a592-5a1e30992566",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAdministration.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write assignments and their grades for all users.",
+                "consentDisplayName":  "Read and write class assignments with grades",
+                "id":  "0d22204b-6cad-4dd0-8362-3e3f2ae699d9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read assignments and their grades for all users.",
+                "consentDisplayName":  "Read class assignments with grades",
+                "id":  "4c37e1b6-35a1-43bf-926a-6f30f2cdf585",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write assignments without grades for all users.",
+                "consentDisplayName":  "Read and write class assignments without grades",
+                "id":  "f431cc63-a2de-48c4-8054-a34bc093af84",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadWriteBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read assignments without grades for all users.",
+                "consentDisplayName":  "Read class assignments without grades",
+                "id":  "6e0a958b-b7fc-4348-b7c4-a6ab9fd3dd0e",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write the structure of schools and classes in the organization's roster and education-specific information about all users to be read and written.",
+                "consentDisplayName":  "Read and write the organization's roster",
+                "id":  "d1808e82-ce13-47af-ae0d-f9b254e6d58a",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the structure of schools and classes in the organization's roster and education-specific information about all users to be read.",
+                "consentDisplayName":  "Read the organization's roster",
+                "id":  "e0ac9e1b-cb65-4fc5-87c5-1a8bc181f648",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read a limited subset of properties from both the structure of schools and classes in the organization's roster and education-specific information about all users. Includes name, status, role, email address and photo.",
+                "consentDisplayName":  "Read a limited subset of the organization's roster",
+                "id":  "0d412a8c-a06c-439f-b3ec-8abcf54d2f96",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.ReadBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete user's mailbox settings without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read and write all user mailbox settings",
+                "id":  "6931bccd-447a-43d1-b442-00a195474933",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "MailboxSettings.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all the OneNote notebooks in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read and write all OneNote notebooks",
+                "id":  "0c458cef-11f3-48c2-a568-c66751c238c0",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Notes.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all the OneNote notebooks in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read all OneNote notebooks",
+                "id":  "3aeca27b-ee3a-4c2b-8ded-80376e2134a4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Notes.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write all domain properties without a signed in user. ?Also allows the app to add, ?verify and remove domains.",
+                "consentDisplayName":  "Read and write domains",
+                "id":  "7e05723c-0bb0-42da-be95-ae9f08a6e53c",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Domain.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to invite guest users to the organization, without a signed-in user.",
+                "consentDisplayName":  "Invite guest users to the organization",
+                "id":  "09850681-111b-4a89-9bed-3f2cae46d706",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.Invite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read user's mailbox settings without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read all user mailbox settings",
+                "id":  "40f97065-369a-49f4-947c-6a255697ae91",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "MailboxSettings.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the memberships of hidden groups and administrative units without a signed-in user.",
+                "consentDisplayName":  "Read all hidden memberships",
+                "id":  "658aa5d8-239f-45c4-aa12-864f4fc7e490",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Member.Read.Hidden"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read mail in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read mail in all mailboxes",
+                "id":  "810c84a8-4a9e-49e6-bf7d-12d183f40d01",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete mail in all mailboxes without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read and write mail in all mailboxes",
+                "id":  "e2a3a72e-5f79-4c64-b1b1-878b674786c9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to send mail as any user without a signed-in user.",
+                "consentDisplayName":  "Send mail as any user",
+                "id":  "b633e1c5-b582-4048-a93e-9f11b44c7e96",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.Send"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all contacts in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read contacts in all mailboxes",
+                "id":  "089fe4d0-434a-44c5-8827-41ba8a0b17f5",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Contacts.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete all contacts in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read and write contacts in all mailboxes",
+                "id":  "6918b873-d17a-4dc1-b314-35f528134491",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Contacts.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read group properties and memberships, and read the calendar and conversations for all groups, without a signed-in user.",
+                "consentDisplayName":  "Read all groups",
+                "id":  "5b567255-7703-4780-807c-7be8301ae99b",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Group.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create groups, read all group properties and memberships, update group properties and memberships, and delete groups. Also allows the app to read and write group calendar and conversations.  All of these operations can be performed by the app without a signed-in user.",
+                "consentDisplayName":  "Read and write all groups",
+                "id":  "62a82d76-70ea-41e2-9197-370581804d09",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Group.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read data in your organization's directory, such as users, groups and apps, without a signed-in user.",
+                "consentDisplayName":  "Read directory data",
+                "id":  "7ab1d382-f21e-4acd-a863-ba3e13f7da61",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Directory.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write data in your organization's directory, such as users, and groups, without a signed-in user.  Does not allow user or group deletion.",
+                "consentDisplayName":  "Read and write directory data",
+                "id":  "19dbc75e-c2e2-444c-a770-ec69d8559fc7",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Directory.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write all device properties without a signed in user.  Does not allow device creation, device deletion or update of device alternative security identifiers.",
+                "consentDisplayName":  "Read and write devices",
+                "id":  "1138cb37-bd11-4084-a2b7-9f71582aeddb",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Device.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read user profiles without a signed in user.",
+                "consentDisplayName":  "Read all users' full profiles",
+                "id":  "df021288-bdef-4463-88db-98f22de89214",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and update user profiles without a signed in user.",
+                "consentDisplayName":  "Read and write all users' full profiles",
+                "id":  "741f803b-c850-494e-b5df-cde7c675a1ca",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the identity risk event information for your organization without a signed in user.",
+                "consentDisplayName":  "Read all identity risk event information",
+                "id":  "6e472fd1-ad78-48da-a0f0-97ab2c6b769e",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "IdentityRiskEvent.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read events of all calendars without a signed-in user.",
+                "consentDisplayName":  "Read calendars in all mailboxes",
+                "id":  "798ee544-9d2d-430c-a058-570e29e34338",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calendars.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete events of all calendars without a signed-in user.",
+                "consentDisplayName":  "Read and write calendars in all mailboxes",
+                "id":  "ef54d2bf-783f-4e0f-bca1-3210c0444d99",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calendars.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, create, update and delete all files in all site collections without a signed in user. ",
+                "consentDisplayName":  "Read and write files in all site collections",
+                "id":  "75359482-378d-4052-8f01-80520e7db3cd",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Files.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all files in all site collections without a signed in user.",
+                "consentDisplayName":  "Read files in all site collections",
+                "id":  "01d4889c-1287-42c6-ac1f-5d1e02578ef6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Files.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create or delete document libraries and lists in all site collections without a signed in user.",
+                "consentDisplayName":  "Create, edit, and delete items and lists in all site collections",
+                "id":  "0c0bf378-bf22-4481-8f81-9e89a9b4960a",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.Manage.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to have full control of all site collections without a signed in user.",
+                "consentDisplayName":  "Have full control of all site collections",
+                "id":  "a82116e5-55eb-4c41-a434-62fe8a61c773",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.FullControl.All"
+            }
+        ]
+}

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -24,6 +24,7 @@
       ".\\Permissions\\apiPermissionsAndScopes-v1.0_ver1.json",
       ".\\Permissions\\apiPermissionsAndScopes-beta_ver1.json",
       ".\\Permissions\\apiPermissionsAndScopes-v1.0_ver2.json"
-    ]
+    ],
+    "ScopesInformationList": ".\\Permissions\\ScopesInformationList.json"
   }
 }

--- a/PermissionsService.Test/PermissionsService.Test.csproj
+++ b/PermissionsService.Test/PermissionsService.Test.csproj
@@ -13,6 +13,7 @@
     <None Remove="TestFiles\permissions-test-file-v1.0_empty.json" />
     <None Remove="TestFiles\permissions-test-file-v1.0_ver1.json" />
     <None Remove="TestFiles\permissions-test-file-v1.0_ver2.json" />
+    <None Remove="TestFiles\ScopesInformationList-test-file.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,6 +33,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestFiles\permissions-test-file-v1.0_ver2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestFiles\ScopesInformationList-test-file.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/PermissionsService.Test/TestFiles/ScopesInformationList-test-file.json
+++ b/PermissionsService.Test/TestFiles/ScopesInformationList-test-file.json
@@ -1,0 +1,1758 @@
+{
+    "delegatedScopesList":
+        [
+            {
+                "adminConsentDescription":  "Allows the app to read identity risky user information for all users in your organization on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read identity risky user information",
+                "id":  "d04bb851-cb7c-4146-97c7-ca3e71baf56c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read identity risky user information for all users in your organization on behalf of the signed-in user.",
+                "consentDisplayName":  "Read identity risky user information",
+                "value":  "identityriskyuser.read.all"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to deliver its notifications on behalf of signed-in users. Also allows the app to read, update, and delete the user's notification items for this app.",
+                "adminConsentDisplayName":  "Deliver and manage user notifications for this app",
+                "id":  "89497502-6e42-46a2-8cb2-427fd3df970a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to deliver its notifications, on your behalf. Also allows the app to read, update, and delete your notification items for this app.",
+                "consentDisplayName":  "Deliver and manage your notifications for this app",
+                "value":  "Notifications.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write your organization's conditional access policies on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write your organization's conditional access policies",
+                "id":  "ad902697-1014-4ef5-81ef-2b4301988e8c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write your organization's conditional access policies on your behalf.",
+                "consentDisplayName":  "Read and write your organization's conditional access policies",
+                "value":  "Policy.ReadWrite.ConditionalAccess"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's policies on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read your organization's policies",
+                "id":  "572fea84-0151-49b2-9301-11cb16974376",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's policies on your behalf.",
+                "consentDisplayName":  "Read your organization's policies",
+                "value":  "Policy.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read access reviews, reviewers, decisions and settings that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all access reviews that user can access",
+                "id":  "ebfcd32b-babb-40f4-a14b-42706e83bd28",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read information on access reviews, reviewers, decisions and settings that you have access to.",
+                "consentDisplayName":  "Read access reviews that you can access",
+                "value":  "AccessReview.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, update, delete and perform actions on access reviews, reviewers, decisions and settings that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Manage all access reviews that user can access",
+                "id":  "e4aa47b9-9a69-4109-82ed-36ec70d85ff1",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read, update and perform action on access reviews, reviewers, decisions and settings that you have access to.",
+                "consentDisplayName":  "Manage access reviews that you can access",
+                "value":  "AccessReview.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read programs and program controls that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all programs that user can access",
+                "id":  "c492a2e1-2f8f-4caa-b076-99bbf6e40fe4",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read information on programs and program controls that you have access to.",
+                "consentDisplayName":  "Read programs that you can access",
+                "value":  "ProgramControl.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, update, delete and perform actions on programs and program controls that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Manage all programs that user can access",
+                "id":  "50fd364f-9d93-4ae1-b170-300e87cccf84",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read, update and perform action on programs and program controls that you have access to.",
+                "consentDisplayName":  "Manage programs that you can access",
+                "value":  "ProgramControl.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete apps in the app catalogs.",
+                "adminConsentDisplayName":  "Read and write to all app catalogs",
+                "id":  "1ca167d5-1655-44a1-8adf-1414072e1ef9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to create, read, update, and delete apps in the app catalogs.",
+                "consentDisplayName":  "Read and write to all app catalogs",
+                "value":  "AppCatalog.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+                "adminConsentDisplayName":  "Export user's data",
+                "id":  "405a51b5-8d8d-430b-9842-8be4b0e9f324",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to export data (e.g. customer content or system-generated logs), associated with any user in your company, when the app is used by a privileged user (e.g. a Company Administrator).",
+                "consentDisplayName":  "Export user's data",
+                "value":  "User.Export.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to request and manage just in time elevation (including scheduled elevation) of users to Azure AD built-in administrative roles, on behalf of signed-in users.",
+                "adminConsentDisplayName":  "Read and write privileged access to Azure AD",
+                "id":  "3c3c74f5-cdaa-4a97-b7e0-4e788bfcfb37",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to request and manage just in time elevation (including scheduled elevation) of users to Azure AD built-in administrative roles, on your behalf.",
+                "consentDisplayName":  "Read and write privileged access to Azure AD",
+                "value":  "PrivilegedAccess.ReadWrite.AzureAD"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to request and manage time-based assignment and just-in-time elevation of user privileges to manage Azure resources (like subscriptions, resource groups, storage, compute) on behalf of the signed-in users.",
+                "adminConsentDisplayName":  "Read and write privileged access to Azure resources",
+                "id":  "a84a9652-ffd3-496e-a991-22ba5529156a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to request and manage time-based assignment and just-in-time elevation of user privileges to manage ?your Azure resources (like your subscriptions, resource groups, storage, compute) on your behalf.",
+                "consentDisplayName":  "Read and write privileged access to your Azure resources",
+                "value":  "PrivilegedAccess.ReadWrite.AzureResources"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read all webhook subscriptions on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all webhook subscriptions (preview)",
+                "id":  "5f88184c-80bb-4d52-9ff2-757288b2e9b7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read all webhook subscriptions on your behalf.",
+                "consentDisplayName":  "Read all webhook subscriptions (preview)",
+                "value":  "Subscription.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use agreements on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all terms of use agreements",
+                "id":  "af2819c9-df71-4dd3-ade7-4d7c9dc653b7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read terms of use agreements on your behalf.",
+                "consentDisplayName":  "Read all terms of use agreements",
+                "value":  "Agreement.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write terms of use agreements on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write all terms of use agreements",
+                "id":  "ef4b5d93-3104-4664-9053-a5c49ab44218",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write terms of use agreements on your behalf.",
+                "consentDisplayName":  "Read and write all terms of use agreements",
+                "value":  "Agreement.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use acceptance statuses on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user terms of use acceptance statuses",
+                "id":  "0b7643bb-5336-476f-80b5-18fbfbc91806",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your terms of use acceptance statuses.",
+                "consentDisplayName":  "Read your terms of use acceptance statuses",
+                "value":  "AgreementAcceptance.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read terms of use acceptance statuses on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read terms of use acceptance statuses that user can access",
+                "id":  "a66a5341-e66e-4897-9d52-c2df58c2bfb9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read terms of use acceptance statuses on your behalf.",
+                "consentDisplayName":  "Read all terms of use acceptance statuses",
+                "value":  "AgreementAcceptance.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and query your audit log activities, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read audit log data",
+                "id":  "e4c9e354-4dc5-45b8-9e7c-e1393b0b1a20",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and query your audit log activities, on your behalf.",
+                "consentDisplayName":  "Read audit log data",
+                "value":  "AuditLog.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and report the signed-in user's activity in the app.",
+                "adminConsentDisplayName":  "Read and write app activity to users' activity feed",
+                "id":  "47607519-5fb1-47d9-99c7-da4b48f369b1",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read and report your activity in the app.",
+                "consentDisplayName":  "Read and write app activity to your activity feed",
+                "value":  "UserActivity.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "adminConsentDisplayName":  "Read Microsoft Intune Device Configuration and Policies",
+                "id":  "f1493658-876a-4c87-8fa7-edb559b3476a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "consentDisplayName":  "Read Microsoft Intune Device Configuration and Policies",
+                "value":  "DeviceManagementConfiguration.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune Device Configuration and Policies",
+                "id":  "0883f392-0a7a-443d-8c76-16a6d39c7b63",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write properties of Microsoft Intune-managed device configuration and device compliance policies and their assignment to groups.",
+                "consentDisplayName":  "Read and write Microsoft Intune Device Configuration and Policies",
+                "value":  "DeviceManagementConfiguration.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read Microsoft Intune apps",
+                "id":  "4edf5f54-4666-44af-9de9-0144fb4b6e8c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "consentDisplayName":  "Read Microsoft Intune apps",
+                "value":  "DeviceManagementApps.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune apps",
+                "id":  "7b3f05d5-f68c-4b8d-8c59-a2ecd12f24af",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties, group assignments and status of apps, app configurations and app protection policies managed by Microsoft Intune.",
+                "consentDisplayName":  "Read and write Microsoft Intune apps",
+                "value":  "DeviceManagementApps.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "adminConsentDisplayName":  "Read Microsoft Intune RBAC settings",
+                "id":  "49f0cc30-024c-4dfd-ab3e-82e137ee5431",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "consentDisplayName":  "Read Microsoft Intune RBAC settings",
+                "value":  "DeviceManagementRBAC.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune RBAC settings",
+                "id":  "0c5e8a55-87a6-4556-93ab-adc52c4d862d",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties relating to the Microsoft Intune Role-Based Access Control (RBAC) settings.",
+                "consentDisplayName":  "Read and write Microsoft Intune RBAC settings",
+                "value":  "DeviceManagementRBAC.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the properties of devices managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Read Microsoft Intune devices",
+                "id":  "314874da-47d6-4978-88dc-cf0d37f0bb82",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the properties of devices managed by Microsoft Intune.",
+                "consentDisplayName":  "Read devices Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the properties of devices managed by Microsoft Intune. Does not allow high impact operations such as remote wipe and password reset on the device's owner.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune devices",
+                "id":  "44642bfe-8385-4adc-8fc6-fe3cb2c375c3",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the properties of devices managed by Microsoft Intune. Does not allow high impact operations such as remote wipe and password reset on the device's owner.",
+                "consentDisplayName":  "Read and write Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to perform remote high impact actions such as wiping the device or resetting the passcode on devices managed by Microsoft Intune.",
+                "adminConsentDisplayName":  "Perform user-impacting remote actions on Microsoft Intune devices",
+                "id":  "3404d2bf-2b13-457e-a330-c24615765193",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to perform remote high impact actions such as wiping the device or resetting the passcode on devices managed by Microsoft Intune.",
+                "consentDisplayName":  "Perform user-impacting remote actions on Microsoft Intune devices",
+                "value":  "DeviceManagementManagedDevices.PrivilegedOperations.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "adminConsentDisplayName":  "Read and write Microsoft Intune configuration",
+                "id":  "662ed50a-ac44-4eef-ad86-62eed9be2a29",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "consentDisplayName":  "Read and write Microsoft Intune configuration",
+                "value":  "DeviceManagementServiceConfig.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "adminConsentDisplayName":  "Read Microsoft Intune configuration",
+                "id":  "8696daa5-bce5-4b2e-83f9-51b6defc4e1e",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read Microsoft Intune service properties including device enrollment and third party service connection configuration.",
+                "consentDisplayName":  "Read Microsoft Intune configuration",
+                "value":  "DeviceManagementServiceConfig.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's security events on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read your organization's security events",
+                "id":  "64733abd-851e-478a-bffb-e47a14b18235",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's security events on your behalf.",
+                "consentDisplayName":  "Read your organization's security events",
+                "value":  "SecurityEvents.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's security events on behalf of the signed-in user. Also allows the app to update editable properties in security events on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and update your organization's security events",
+                "id":  "6aedf524-7e1c-45a7-bd76-ded8cab8d0fc",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's security events on your behalf. Also allows you to update editable properties in security events.",
+                "consentDisplayName":  "Read and update your organization's security events",
+                "value":  "SecurityEvents.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a scored list of relevant people of the signed-in user or other users in the signed-in user's organization. The list can include local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "adminConsentDisplayName":  "Read all users' relevant people lists",
+                "id":  "b89f9189-71a5-4e70-b041-9887f0bc7e4a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read a list of people in the order that is most relevant to you. Allows the app to read a list of people in the order that is most relevant to another user in your organization. These can include local contacts, contacts from social networking, people listed in your organization's directory, and people from recent communications.",
+                "consentDisplayName":  "Read all users? relevant people lists",
+                "value":  "People.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Manage the state and settings of all Microsoft education apps on behalf of the user.",
+                "adminConsentDisplayName":  "Manage education app settings",
+                "id":  "63589852-04e3-46b4-bae9-15d5b1050748",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to manage the state and settings of all Microsoft education apps on your behalf.",
+                "consentDisplayName":  "Manage your education app settings",
+                "value":  "EduAdministration.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Read the state and settings of all Microsoft education apps on behalf of the user.",
+                "adminConsentDisplayName":  "Read education app settings",
+                "id":  "8523895c-6081-45bf-8a5d-f062a2f12c9f",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view the state and settings of all Microsoft education apps on your behalf.",
+                "consentDisplayName":  "View your education app settings",
+                "value":  "EduAdministration.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write assignments and their grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' class assignments and their grades",
+                "id":  "2f233e90-164b-4501-8bce-31af2559a2d3",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify your assignments on your behalf including ?grades.",
+                "consentDisplayName":  "View and modify your assignments and grades",
+                "value":  "EduAssignments.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read assignments and their grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' class assignments and their grades",
+                "id":  "091460c9-9c4a-49b2-81ef-1f3d852acce2",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view your assignments on your behalf including grades.",
+                "consentDisplayName":  "View your assignments and grades",
+                "value":  "EduAssignments.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write assignments without grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' class assignments without grades",
+                "id":  "2ef770a1-622a-47c4-93ee-28d6adbed3a0",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify your assignments on your behalf without seeing grades.",
+                "consentDisplayName":  "View and modify your assignments without grades",
+                "value":  "EduAssignments.ReadWriteBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read assignments without grades on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' class assignments without grades",
+                "id":  "c0b0103b-c053-4b2e-9973-9f3a544ec9b8",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view your assignments on your behalf without seeing grades.",
+                "consentDisplayName":  "View your assignments without grades",
+                "value":  "EduAssignments.ReadBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the structure of schools and classes in an organization's roster and education-specific information about users to be read and written on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write users' view of the roster",
+                "id":  "359e19a6-e3fa-4d7f-bcab-d28ec592b51e",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view and modify information about schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View and modify your school, class and user information",
+                "value":  "EduRoster.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the structure of schools and classes in an organization's roster and education-specific information about users to be read on behalf of the user.",
+                "adminConsentDisplayName":  "Read users' view of the roster",
+                "id":  "a4389601-22d9-4096-ac18-36a927199112",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view information about schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View your school, class and user information",
+                "value":  "EduRoster.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a limited subset of the properties from the structure of schools and classes in an organization's roster and a limited subset of properties about users to be read on behalf of the user.?Includes name, status, education role, email address and photo.",
+                "adminConsentDisplayName":  "Read a limited subset of users' view of the roster",
+                "id":  "5d186531-d1bf-4f07-8cea-7c42119e1bd9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to view minimal ?information about both schools and classes in your organization and education-related information about you and other users on your behalf.",
+                "consentDisplayName":  "View a limited subset of your school, class and user information",
+                "value":  "EduRoster.ReadBasic"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to report the signed-in user's app activity information to Microsoft Timeline.",
+                "adminConsentDisplayName":  "Write app activity to users' timeline",
+                "id":  "367492fc-594d-4972-a9b5-0d58c622c91c",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to report your app activity information to Microsoft Timeline.",
+                "consentDisplayName":  "Write app activity to your timeline",
+                "value":  "UserTimelineActivity.Write.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete user's mailbox settings. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read and write user mailbox settings",
+                "id":  "818c620a-27a9-40bd-a6a5-d96f7d610b4b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete your mailbox settings.",
+                "consentDisplayName":  "Read and write to your mailbox settings",
+                "value":  "MailboxSettings.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to launch another app or communicate with another app on a user's device on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Communicate with user devices",
+                "id":  "bac3b9c2-b516-4ef4-bd3b-c2ef73d8d804",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to launch another app or communicate with another app on a device that you own.",
+                "consentDisplayName":  "Communicate with your other devices",
+                "value":  "Device.Command"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a user's list of devices on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user devices",
+                "id":  "11d4cd79-5ba5-460f-803f-e22c8ab85ccd",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see your list of devices.",
+                "consentDisplayName":  "View your list of devices",
+                "value":  "Device.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, share, and modify OneNote notebooks that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read and write all OneNote notebooks that user can access",
+                "id":  "64ac0503-b4fa-45d9-b544-71a463f05da0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, share, and modify all the OneNote notebooks that you have access to.",
+                "consentDisplayName":  "Read and write all OneNote notebooks that you can access",
+                "value":  "Notes.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read OneNote notebooks that the signed-in user has access to in the organization.",
+                "adminConsentDisplayName":  "Read all OneNote notebooks that user can access",
+                "id":  "dfabfca6-ee36-4db2-8208-7a28381419b3",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read all the OneNote notebooks that you have access to.",
+                "consentDisplayName":  "Read all OneNote notebooks that you can access",
+                "value":  "Notes.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, share, and modify OneNote notebooks on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write user OneNote notebooks",
+                "id":  "615e26af-c38a-4150-ae3e-c3b0d4cb1d6a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, share, and modify OneNote notebooks on your behalf.",
+                "consentDisplayName":  "Read and write your OneNote notebooks",
+                "value":  "Notes.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read OneNote notebooks on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read user OneNote notebooks",
+                "id":  "371361e4-b9e2-4a3f-8315-2a301a3b0a3d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read OneNote notebooks on your behalf.",
+                "consentDisplayName":  "Read your OneNote notebooks",
+                "value":  "Notes.Read"
+            },
+            {
+                "adminConsentDescription":  "This is deprecated!  Do not use! This permission no longer has any effect. You can safely consent to it. No additional privileges will be granted to the app.",
+                "adminConsentDisplayName":  "Limited notebook access (deprecated)",
+                "id":  "ed68249d-017c-4df5-9113-e684c7f8760b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "This permission no longer has any effect. You can safely consent to it. No additional privileges will be granted to the app.",
+                "consentDisplayName":  "Limited access to your OneNote notebooks for this app (preview)",
+                "value":  "Notes.ReadWrite.CreatedByApp"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the titles of OneNote notebooks and sections and to create new pages, notebooks, and sections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Create user OneNote notebooks",
+                "id":  "9d822255-d64d-4b7a-afdb-833b9a97ed02",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to view the titles of your OneNote notebooks and sections and to create new pages, notebooks, and sections on your behalf.",
+                "consentDisplayName":  "Create your OneNote notebooks",
+                "value":  "Notes.Create"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to invite guest users to the organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Invite guest users to the organization",
+                "id":  "63dd7cd9-b489-4adf-a28c-ac38b9a0f962",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to invite guest users to the organization, on your behalf.",
+                "consentDisplayName":  "Invite guest users to the organization",
+                "value":  "User.Invite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to the read user's mailbox settings. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read user mailbox settings",
+                "id":  "87f447af-9fa4-4c32-9dfa-4a57a73d18ce",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your mailbox settings.",
+                "consentDisplayName":  "Read your mailbox settings",
+                "value":  "MailboxSettings.Read"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read files that the user selects. The app has access for several hours after the user selects a file.",
+                "adminConsentDisplayName":  "Read files that the user selects (preview)",
+                "id":  "5447fe39-cb82-4c1a-b977-520e67e724eb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read files that you select. After you select a file, the app has access to the file for several hours.",
+                "consentDisplayName":  "Read selected files",
+                "value":  "Files.Read.Selected"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read and write files that the user selects. The app has access for several hours after the user selects a file.",
+                "adminConsentDisplayName":  "Read and write files that the user selects (preview)",
+                "id":  "17dde5bd-8c17-420f-a486-969730c1b827",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read and write files that you select. After you select a file, the app has access to the file for several hours.",
+                "consentDisplayName":  "Read and write selected files",
+                "value":  "Files.ReadWrite.Selected"
+            },
+            {
+                "adminConsentDescription":  "(Preview) Allows the app to read, create, update and delete files in the application's folder.",
+                "adminConsentDisplayName":  "Have full access to the application's folder (preview)",
+                "id":  "8019c312-3263-48e6-825e-2b833497195b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "(Preview) Allows the app to read, create, update and delete files in the application's folder.",
+                "consentDisplayName":  "Have full access to the application's folder",
+                "value":  "Files.ReadWrite.AppFolder"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read all service usage reports on behalf of the signed-in user.  Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "adminConsentDisplayName":  "Read all usage reports",
+                "id":  "02e97553-ed7b-43d0-ab3c-f8bace0d040c",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows an app to read all service usage reports on your behalf. Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "consentDisplayName":  "Read all usage reports",
+                "value":  "Reports.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to edit or delete documents and list items in all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Edit or delete items in all site collections",
+                "id":  "89fe6a52-be36-487e-b7d8-d061c450a026",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to edit or delete documents and list items in all site collections on your behalf.",
+                "consentDisplayName":  "Edit or delete items in all site collections",
+                "value":  "Sites.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete tasks a user has permissions to, including their own and shared tasks.",
+                "adminConsentDisplayName":  "Read and write user and shared tasks",
+                "id":  "c5ddf11b-c114-4886-8558-8a4e557cd52b",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete tasks you have permissions to access, including your own and shared tasks.",
+                "consentDisplayName":  "Read and write to your and shared tasks",
+                "value":  "Tasks.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read tasks a user has permissions to access, including their own and shared tasks.",
+                "adminConsentDisplayName":  "Read user and shared tasks",
+                "id":  "88d21fd4-8e5a-4c32-b5e2-4a1c95f34f72",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read tasks you have permissions to access, including your own and shared tasks.",
+                "consentDisplayName":  "Read your and shared tasks",
+                "value":  "Tasks.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete contacts a user has permissions to, including their own and shared contacts.",
+                "adminConsentDisplayName":  "Read and write user and shared contacts",
+                "id":  "afb6c84b-06be-49af-80bb-8f3f77004eab",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete contacts you have permissions to access, including your own and shared contacts.",
+                "consentDisplayName":  "Read and write to your and shared contacts",
+                "value":  "Contacts.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read contacts a user has permissions to access, including their own and shared contacts.",
+                "adminConsentDisplayName":  "Read user and shared contacts",
+                "id":  "242b9d9e-ed24-4d09-9a52-f43769beb9d4",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read contacts you have permissions to access, including your own and shared contacts.",
+                "consentDisplayName":  "Read your and shared contacts",
+                "value":  "Contacts.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update and delete events in all calendars in the organization user has permissions to access. This includes delegate and shared calendars.",
+                "adminConsentDisplayName":  "Read and write user and shared calendars",
+                "id":  "12466101-c9b8-439a-8589-dd09ee67e8e9",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete events in all calendars in your organization you have permissions to access. This includes delegate and shared calendars.",
+                "consentDisplayName":  "Read and write to your and shared calendars",
+                "value":  "Calendars.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read events in all calendars that the user can access, including delegate and shared calendars.",
+                "adminConsentDisplayName":  "Read user and shared calendars",
+                "id":  "2b9c4092-424d-4249-948d-b43879977640",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read events in all calendars that you can access, including delegate and shared calendars.?",
+                "consentDisplayName":  "Read calendars?you can access",
+                "value":  "Calendars.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to send mail as the signed-in user, including sending on-behalf of others.",
+                "adminConsentDisplayName":  "Send mail on behalf of others",
+                "id":  "a367ab51-6b49-43bf-a716-a1fb06d2a174",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to send mail as you or on-behalf of someone else.",
+                "consentDisplayName":  "Send mail on behalf of others or yourself",
+                "value":  "Mail.Send.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete mail a user has permission to access, including their own and shared mail. Does not include permission to send mail.",
+                "adminConsentDisplayName":  "Read and write user and shared mail",
+                "id":  "5df07973-7d5d-46ed-9847-1271055cbd51",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create, and delete mail you have permission to access, including your own and shared mail. Does not allow the app to send mail on your behalf.",
+                "consentDisplayName":  "Read and write mail?you can access",
+                "value":  "Mail.ReadWrite.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read mail a user can access, including their own and shared mail.",
+                "adminConsentDisplayName":  "Read user and shared mail",
+                "id":  "7b9103a5-4610-446b-9670-80643382c1fa",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read mail you can access, including shared mail.",
+                "consentDisplayName":  "Read mail you can access",
+                "value":  "Mail.Read.Shared"
+            },
+            {
+                "adminConsentDescription":  "Allows users to sign-in to the app, and allows the app to read the profile of signed-in users. It also allows the app to read basic company information of signed-in users.",
+                "adminConsentDisplayName":  "Sign in and read user profile",
+                "id":  "e1fe6dd8-ba31-4d61-89e7-88639da4683d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows you to sign in to the app with your organizational account and let the app read your profile. It also allows the app to read basic company information.",
+                "consentDisplayName":  "Sign you in and read your profile",
+                "value":  "User.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your profile. It also allows the app to update your profile information on your behalf.",
+                "adminConsentDisplayName":  "Read and write access to user profile",
+                "id":  "b4e74841-8e56-480b-be8b-910348b18b4c",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your profile, and discover your group membership, reports and manager. It also allows the app to update your profile information on your behalf.",
+                "consentDisplayName":  "Read and update your profile",
+                "value":  "User.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a basic set of profile properties of other users in your organization on behalf of the signed-in user. This includes display name, first and last name, email address and photo.",
+                "adminConsentDisplayName":  "Read all users' basic profiles",
+                "id":  "b340eb25-3456-403f-be2f-af7a0d370277",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read a basic set of profile properties of other users in your organization on your behalf. Includes display name, first and last name, email address and photo.",
+                "consentDisplayName":  "Read all users' basic profiles",
+                "value":  "User.ReadBasic.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read all users' full profiles",
+                "id":  "a154be20-db9c-4678-8ab7-66f6cc099a59",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+                "consentDisplayName":  "Read all users' full profiles",
+                "value":  "User.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write all users' full profiles",
+                "id":  "204e0828-b5ca-4ad8-b9f3-f32a958e7cc4",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write the full set of profile properties, reports, and managers of other users in your organization, on your behalf.",
+                "consentDisplayName":  "Read and write all users' full profiles",
+                "value":  "User.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to list groups, and to read their properties and all group memberships on behalf of the signed-in user.  Also allows the app to read calendar, conversations, files, and other group content for all groups the signed-in user can access. ",
+                "adminConsentDisplayName":  "Read all groups",
+                "id":  "5f8c59db-677d-491f-a6b8-5f174b11ec1d",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to list groups, and to read their properties and all group memberships on your behalf.  Also allows the app to read calendar, conversations, files, and other group content for all groups you can access.  ",
+                "consentDisplayName":  "Read all groups",
+                "value":  "Group.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create groups and read all group properties and memberships on behalf of the signed-in user.  Additionally allows group owners to manage their groups and allows group members to update group content.",
+                "adminConsentDisplayName":  "Read and write all groups",
+                "id":  "4e46008b-f24c-477d-8fff-7bb4ec7aafe0",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to create groups and read all group properties and memberships on your behalf.  Additionally allows the app to manage your groups and to update group content for groups you are a member of.",
+                "consentDisplayName":  "Read and write all groups",
+                "value":  "Group.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read data in your organization's directory, such as users, groups and apps.",
+                "adminConsentDisplayName":  "Read directory data",
+                "id":  "06da0dbc-49e2-44d2-8312-53f166ab848a",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read data in your organization's directory.",
+                "consentDisplayName":  "Read directory data",
+                "value":  "Directory.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write data in your organization's directory, such as users, and groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+                "adminConsentDisplayName":  "Read and write directory data",
+                "id":  "c5366453-9fb0-48a5-a156-24f0c49a4b84",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write data in your organization's directory, such as other users, groups.  It does not allow the app to delete users or groups, or reset user passwords.",
+                "consentDisplayName":  "Read and write directory data",
+                "value":  "Directory.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to have the same access to information in the directory as the signed-in user.",
+                "adminConsentDisplayName":  "Access directory as the signed in user",
+                "id":  "0e263e50-5827-48a4-b97c-d940288653c7",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to have the same access to information in your work or school directory as you do.",
+                "consentDisplayName":  "Access the directory as you",
+                "value":  "Directory.AccessAsUser.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read email in user mailboxes. ",
+                "adminConsentDisplayName":  "Read user mail ",
+                "id":  "570282fd-fa5c-430d-a7fd-fc8dc98a9dca",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read email in your mailbox. ",
+                "consentDisplayName":  "Read your mail ",
+                "value":  "Mail.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete email in user mailboxes. Does not include permission to send mail. ",
+                "adminConsentDisplayName":  "Read and write access to user mail ",
+                "id":  "024d486e-b451-40bb-833d-3e66d98c5c73",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete email in your mailbox. Does not include permission to send mail. ",
+                "consentDisplayName":  "Read and write access to your mail ",
+                "value":  "Mail.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to send mail as users in the organization. ",
+                "adminConsentDisplayName":  "Send mail as a user ",
+                "id":  "e383f46e-2787-4529-855e-0e479a3ffac0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to send mail as you. ",
+                "consentDisplayName":  "Send mail as you ",
+                "value":  "Mail.Send"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read events in user calendars . ",
+                "adminConsentDisplayName":  "Read user calendars ",
+                "id":  "465a38f9-76ea-45b9-9f34-9e8b0d4b0b42",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read events in your calendars. ",
+                "consentDisplayName":  "Read your calendars ",
+                "value":  "Calendars.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete events in user calendars. ",
+                "adminConsentDisplayName":  "Have full access to user calendars ",
+                "id":  "1ec239c2-d7c9-4623-a91a-a9775856bb36",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete events in your calendars. ",
+                "consentDisplayName":  "Have full access to your calendars  ",
+                "value":  "Calendars.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read user contacts.  ",
+                "adminConsentDisplayName":  "Read user contacts ",
+                "id":  "ff74d97f-43af-4b68-9f2a-b77ee6968c5d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read contacts in your contact folders. ",
+                "consentDisplayName":  "Read your contacts ",
+                "value":  "Contacts.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update, and delete user contacts. ",
+                "adminConsentDisplayName":  "Have full access to user contacts ",
+                "id":  "d56682ec-c09e-4743-aaf4-1a3aac4caa21",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, update, create and delete contacts in your contact folders. ",
+                "consentDisplayName":  "Have full access of your contacts ",
+                "value":  "Contacts.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the signed-in user's files.",
+                "adminConsentDisplayName":  "Read user files",
+                "id":  "10465720-29dd-4523-a11a-6a75c743c9d9",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your files.",
+                "consentDisplayName":  "Read your files",
+                "value":  "Files.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, create, update and delete the signed-in user's files.",
+                "adminConsentDisplayName":  "Have full access to user files",
+                "id":  "5c28f0bf-8a70-41f1-8ab2-9032436ddb65",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, create, update, and delete your files.",
+                "consentDisplayName":  "Have full access to your files",
+                "value":  "Files.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read all files the signed-in user can access.",
+                "adminConsentDisplayName":  "Read all files that user can access",
+                "id":  "df85f4d6-205c-4ac5-a5ea-6bf408dba283",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read all files you can access.",
+                "consentDisplayName":  "Read all files that you have access to",
+                "value":  "Files.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read, create, update and delete all files the signed-in user can access.",
+                "adminConsentDisplayName":  "Have full access to all files user can access",
+                "id":  "863451e7-0667-486c-a5d6-d135439485f0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read, create, update and delete all files that you can access.",
+                "consentDisplayName":  "Have full access to all files you have access to",
+                "value":  "Files.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to read documents and list  items in all site collections on behalf of the signed-in user",
+                "adminConsentDisplayName":  "Read items in all site collections",
+                "id":  "205e70e5-aba6-4c52-a976-6d2d46c48043",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to read documents and list items in all site collections on your behalf",
+                "consentDisplayName":  "Read items in all site collections",
+                "value":  "Sites.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows users to sign in to the app with their work or school accounts and allows the app to see basic user profile information.",
+                "adminConsentDisplayName":  "Sign users in",
+                "id":  "37f7f235-527c-4136-accd-4a02d197296e",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows you to sign in to the app with your work or school account and allows the app to read your basic profile information.",
+                "consentDisplayName":  "Sign in as you",
+                "value":  "openid"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and update user data, even when they are not currently using the app.",
+                "adminConsentDisplayName":  "Access user's data anytime",
+                "id":  "7427e0e9-2fba-42fe-b0c0-848c9e6a8182",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see and update your data, even when you are not currently using the app.",
+                "consentDisplayName":  "Access your data anytime",
+                "value":  "offline_access"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read user tasks",
+                "adminConsentDisplayName":  "Read user tasks",
+                "id":  "f45671fb-e0fe-4b4b-be20-3d3ce43f1bcb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your tasks",
+                "consentDisplayName":  "Read your tasks",
+                "value":  "Tasks.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your users' primary email address",
+                "adminConsentDisplayName":  "View users' email address",
+                "id":  "64a6cdd6-aab1-4aaf-94b8-3cc8405e90d0",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read your primary email address",
+                "consentDisplayName":  "View your email address",
+                "value":  "email"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to see your users' basic profile (name, picture, user name)",
+                "adminConsentDisplayName":  "View users' basic profile",
+                "id":  "14dad69e-099b-42c9-810b-d002981feec1",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to see your basic profile (name, picture, user name)",
+                "consentDisplayName":  "View your basic profile",
+                "value":  "profile"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read identity risk event information for all users in your organization on behalf of the signed-in user. ",
+                "adminConsentDisplayName":  "Read identity risk event information",
+                "id":  "8f6a01e7-0391-4ee5-aa22-a3af122cef27",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read identity risk event information for all users in your organization on behalf of the signed-in user. ",
+                "consentDisplayName":  "Read identity risk event information",
+                "value":  "IdentityRiskEvent.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read the memberships of hidden groups and administrative units on behalf of the signed-in user, for those hidden groups and administrative units that the signed-in user has access to.",
+                "adminConsentDisplayName":  "Read hidden memberships",
+                "id":  "f6a3db3e-f7e8-4ed2-a414-557c8c9830be",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read the memberships of hidden groups or administrative units on your behalf, for those hidden groups or adminstrative units that you have access to.",
+                "consentDisplayName":  "Read your hidden memberships",
+                "value":  "Member.Read.Hidden"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to create, read, update and delete tasks and plans (and tasks in them), that are assigned to or shared with the signed-in user.",
+                "adminConsentDisplayName":  "Create, read, update and delete user tasks and projects",
+                "id":  "2219042f-cab5-40cc-b0d2-16b1540b4c5f",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to create, read, update and delete tasks assigned to you and plans (and tasks in them) shared with or owned by you.",
+                "consentDisplayName":  "Create, read, update and delete your tasks and projects",
+                "value":  "Tasks.ReadWrite"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read a ranked list of relevant people of the signed-in user. The list includes local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "adminConsentDisplayName":  "Read users' relevant people lists",
+                "id":  "ba47897c-39ec-4d83-8086-ee8256fa737d",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read a list of people in the order that's most relevant to you. This includes your local contacts, your contacts from social networking, people listed in your organization's directory, and people from recent communications.",
+                "consentDisplayName":  "Read your relevant people list",
+                "value":  "People.Read"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to create or delete document libraries and lists in all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Create, edit, and delete items and lists in all site collections",
+                "id":  "65e50fdc-43b7-4915-933e-e8138f11f40a",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allow the application to create or delete document libraries and lists in all site collections on your behalf.",
+                "consentDisplayName":  "Create, edit, and delete items and lists in all your site collections",
+                "value":  "Sites.Manage.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the application to have full control of all site collections on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Have full control of all site collections",
+                "id":  "5a54b8b3-347c-476d-8f8e-42d5c7424d29",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allow the application to have full control of all site collections on your behalf.",
+                "consentDisplayName":  "Have full control of all your site collections",
+                "value":  "Sites.FullControl.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write your organization's identity (authentication) providers? properties on behalf of the user.",
+                "adminConsentDisplayName":  "Read and write identity providers",
+                "id":  "f13ce604-1677-429f-90bd-8a10b9f01325",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read and write your organization's identity (authentication) providers? properties on your behalf.",
+                "consentDisplayName":  "Read and write identity providers",
+                "value":  "IdentityProvider.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read your organization's identity (authentication) providers? properties on behalf of the user.",
+                "adminConsentDisplayName":  "Read identity providers",
+                "id":  "43781733-b5a7-4d1b-98f4-e8edff23e1a9",
+                "isEnabled":  true,
+                "isAdmin":  true,
+                "consentDescription":  "Allows the app to read your organization's identity (authentication) providers? properties on your behalf.",
+                "consentDisplayName":  "Read identity providers",
+                "value":  "IdentityProvider.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read bookings information",
+                "id":  "33b1df99-4b29-4548-9339-7a7b83eaeebc",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read bookings appointments, businesses, customers, services, and staff on your behalf.",
+                "consentDisplayName":  "Read bookings information",
+                "value":  "Bookings.Read.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read and write bookings appointments and customers, and additionally allows read businesses information, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write booking appointments",
+                "id":  "02a5a114-36a6-46ff-a102-954d89d9ab02",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read and write bookings appointments and customers, and additionally allows read businesses information, services, and staff on your behalf.",
+                "consentDisplayName":  "Read and write booking appointments",
+                "value":  "BookingsAppointment.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read and write bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user. Does not allow create, delete and publish of booking businesses.",
+                "adminConsentDisplayName":  "Read and write bookings information",
+                "id":  "948eb538-f19d-4ec5-9ccc-f059e1ea4c72",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read and write Bookings appointments, businesses, customers, services, and staff on your behalf. Does not allow create, delete and publish of booking businesses.",
+                "consentDisplayName":  "Read and write bookings information",
+                "value":  "Bookings.ReadWrite.All"
+            },
+            {
+                "adminConsentDescription":  "Allows an app to read, write and manage bookings appointments, businesses, customers, services, and staff on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Manage bookings information",
+                "id":  "7f36b48e-542f-4d3b-9bcb-8406f0ab9fdb",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows an app to read, write and manage bookings appointments, businesses, customers, services, and staff on your behalf.",
+                "consentDisplayName":  "Manage bookings information",
+                "value":  "Bookings.Manage.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to have the same access to mailboxes as the signed-in user via Exchange ActiveSync.",
+                "adminConsentDisplayName":  "Access mailboxes via Exchange ActiveSync",
+                "id":  "ff91d191-45a0-43fd-b837-bd682c4a0b0f",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app full access to your mailboxes on your behalf.",
+                "consentDisplayName":  "Access your mailboxes",
+                "value":  "EAS.AccessAsUser.All"
+            },
+            {
+                "adminConsentDescription":  "Allows the app to read and write financials data on behalf of the signed-in user.",
+                "adminConsentDisplayName":  "Read and write financials data",
+                "id":  "f534bf13-55d4-45a9-8f3c-c92fe64d6131",
+                "isEnabled":  true,
+                "isAdmin":  false,
+                "consentDescription":  "Allows the app to read and write financials data on your behalf.",
+                "consentDisplayName":  "Read and write financials data",
+                "value":  "Financials.ReadWrite.All"
+            }
+        ],
+    "applicationScopesList":
+        [
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, update, delete and perform actions on programs and program controls in the organization, without a signed-in user.",
+                "consentDisplayName":  "Manage all programs",
+                "id":  "60a901ed-09f7-4aa5-a16e-7dd3d6f9de36",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ProgramControl.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read programs and program controls in the organization, without a signed-in user.",
+                "consentDisplayName":  "Read all programs",
+                "id":  "eedb7fdd-7539-4345-a38b-4839e4a84cbd",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ProgramControl.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, update, delete and perform actions on access reviews, reviewers, decisions and settings in the organization, without a signed-in user.",
+                "consentDisplayName":  "Manage all access reviews",
+                "id":  "ef5f7d5c-338f-44b0-86c3-351f46c8bb5f",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AccessReview.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read access reviews, reviewers, decisions and settings in the organization, without a signed-in user.",
+                "consentDisplayName":  "Read all access reviews",
+                "id":  "d07a8cc0-3d51-4b77-b3b0-32704d1f69fa",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AccessReview.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the identity risky user information for your organization without a signed in user.",
+                "consentDisplayName":  "Read all identity risky user information",
+                "id":  "dc5007c0-2d7d-4c42-879c-2dab87571379",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "identityriskyuser.read.all"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and create online meetings as an application in your organization.",
+                "consentDisplayName":  "Read and create online meetings (preview)",
+                "id":  "b8bb2037-6e08-44ac-a4ea-4674e010e2a4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "OnlineMeetings.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows an app to read all service usage reports without a signed-in user.  Services that provide usage reports include Office 365 and Azure Active Directory.",
+                "consentDisplayName":  "Read all usage reports",
+                "id":  "230c1aed-a721-4c5d-9cb4-a90514e508ef",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Reports.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read any user's scored list of relevant people, without a signed-in user. The list can include local contacts, contacts from social networking, your organization's directory, and people from recent communications (such as email and Skype).",
+                "consentDisplayName":  "Read all users' relevant people lists",
+                "id":  "b528084d-ad10-4598-8b93-929746b4d7d6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "People.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to update Microsoft Teams 1-to-1 or group chat messages by patching a set of Data Loss Prevention (DLP) policy violation properties to handle the output of DLP processing.",
+                "consentDisplayName":  "Flag chat messages for violating policy",
+                "id":  "7e847308-e030-4183-9899-5235d7270f58",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Chat.UpdatePolicyViolation.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all 1-to-1 or group chat messages in Microsoft Teams.",
+                "consentDisplayName":  "Read all chat messages",
+                "id":  "6b7d71aa-70aa-4810-a8d9-5d9fb2830017",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Chat.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all channel messages in Microsoft Teams",
+                "consentDisplayName":  "Read all channel messages",
+                "id":  "7b2449af-6ccd-4f4d-9f78-e550c193f0d1",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ChannelMessage.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to update Microsoft Teams channel messages by patching a set of Data Loss Prevention (DLP) policy violation properties to handle the output of DLP processing.",
+                "consentDisplayName":  "Flag channel messages for violating policy",
+                "id":  "4d02b0cc-d90b-441f-8d82-4fb55c34d6bb",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "ChannelMessage.UpdatePolicyViolation.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update and delete applications and service principals without a signed-in user.  Does not allow management of consent grants.",
+                "consentDisplayName":  "Read and write all applications",
+                "id":  "1bfefb4e-e0b5-418b-a88f-73c46d2cc8e9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Application.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create other applications, and fully manage those applications (read, update, update application secrets and delete), without a signed-in user. ?It cannot update any apps that it is not an owner of.",
+                "consentDisplayName":  "Manage apps that this app creates or owns",
+                "id":  "18a4783c-866b-4cc7-a460-3d5e5662c884",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Application.ReadWrite.OwnedBy"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read online meeting details in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read online meeting details (preview)",
+                "id":  "c1684f21-1984-47fa-9d61-2dc8c296bb70",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "OnlineMeetings.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to get direct access to media streams in a call, without a signed-in user.",
+                "consentDisplayName":  "Access media streams in a call as an app (preview)",
+                "id":  "a7a681dc-756e-4909-b988-f160edc6655f",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.AccessMedia.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to anonymously join group calls and scheduled meetings in your organization, without a signed-in user. ?The app will be joined as a guest to meetings in your organization.",
+                "consentDisplayName":  "Join group calls and meetings as a guest (preview)",
+                "id":  "fd7ccf6b-3d28-418b-9701-cd10f5cd2fd4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.JoinGroupCallAsGuest.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to join group calls and scheduled meetings in your organization, without a signed-in user. ?The app will be joined with the privileges of a directory user to meetings in your organization.",
+                "consentDisplayName":  "Join group calls and meetings as an app (preview)",
+                "id":  "f6b49018-60ab-4f81-83bd-22caeabfed2d",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.JoinGroupCall.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to place outbound calls to multiple users and add participants to meetings in your organization, without a signed-in user.",
+                "consentDisplayName":  "Initiate outgoing group calls from the app (preview)",
+                "id":  "4c277553-8a09-487b-8023-29ee378d8324",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.InitiateGroupCall.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to place outbound calls to a single user and transfer calls to users in your organization's directory, without a signed-in user.",
+                "consentDisplayName":  "Initiate outgoing 1:1 calls from the app (preview)",
+                "id":  "284383ee-7f6e-4e40-a2a8-e85dcb029101",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calls.Initiate.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and query your audit log activities, without a signed-in user.",
+                "consentDisplayName":  "Read all audit log data",
+                "id":  "b0afded3-3588-46d8-8b3d-9842eff778da",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "AuditLog.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read your organization's security events without a signed-in user.",
+                "consentDisplayName":  "Read your organization's security events",
+                "id":  "bf394140-e372-4bf9-a898-299cfc7564e5",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "SecurityEvents.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read your organization's security events without a signed-in user. Also allows the app to update editable properties in security events.",
+                "consentDisplayName":  "Read and update your organization's security events",
+                "id":  "d903a879-88e0-4c09-b0c9-82f6a1333f84",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "SecurityEvents.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete documents and list items in all site collections without a signed in user.",
+                "consentDisplayName":  "Read and write items in all site collections (preview)",
+                "id":  "9492366f-7969-46a4-8d15-ed1a20078fff",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read documents and list items in all site collections without a signed in user.",
+                "consentDisplayName":  "Read items in all site collections (preview)",
+                "id":  "332a536c-c7ef-4017-ab91-336970924f0d",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Manage the state and settings of all Microsoft education apps.",
+                "consentDisplayName":  "Manage education app settings",
+                "id":  "9bc431c3-b8bc-4a8d-a219-40f10f92eff6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAdministration.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Read the state and settings of all Microsoft education apps.",
+                "consentDisplayName":  "Read Education app settings",
+                "id":  "7c9db06a-ec2d-4e7b-a592-5a1e30992566",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAdministration.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write assignments and their grades for all users.",
+                "consentDisplayName":  "Read and write class assignments with grades",
+                "id":  "0d22204b-6cad-4dd0-8362-3e3f2ae699d9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read assignments and their grades for all users.",
+                "consentDisplayName":  "Read class assignments with grades",
+                "id":  "4c37e1b6-35a1-43bf-926a-6f30f2cdf585",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write assignments without grades for all users.",
+                "consentDisplayName":  "Read and write class assignments without grades",
+                "id":  "f431cc63-a2de-48c4-8054-a34bc093af84",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadWriteBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read assignments without grades for all users.",
+                "consentDisplayName":  "Read class assignments without grades",
+                "id":  "6e0a958b-b7fc-4348-b7c4-a6ab9fd3dd0e",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduAssignments.ReadBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write the structure of schools and classes in the organization's roster and education-specific information about all users to be read and written.",
+                "consentDisplayName":  "Read and write the organization's roster",
+                "id":  "d1808e82-ce13-47af-ae0d-f9b254e6d58a",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the structure of schools and classes in the organization's roster and education-specific information about all users to be read.",
+                "consentDisplayName":  "Read the organization's roster",
+                "id":  "e0ac9e1b-cb65-4fc5-87c5-1a8bc181f648",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read a limited subset of properties from both the structure of schools and classes in the organization's roster and education-specific information about all users. Includes name, status, role, email address and photo.",
+                "consentDisplayName":  "Read a limited subset of the organization's roster",
+                "id":  "0d412a8c-a06c-439f-b3ec-8abcf54d2f96",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "EduRoster.ReadBasic.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete user's mailbox settings without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read and write all user mailbox settings",
+                "id":  "6931bccd-447a-43d1-b442-00a195474933",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "MailboxSettings.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all the OneNote notebooks in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read and write all OneNote notebooks",
+                "id":  "0c458cef-11f3-48c2-a568-c66751c238c0",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Notes.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all the OneNote notebooks in your organization, without a signed-in user.",
+                "consentDisplayName":  "Read all OneNote notebooks",
+                "id":  "3aeca27b-ee3a-4c2b-8ded-80376e2134a4",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Notes.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write all domain properties without a signed in user. ?Also allows the app to add, ?verify and remove domains.",
+                "consentDisplayName":  "Read and write domains",
+                "id":  "7e05723c-0bb0-42da-be95-ae9f08a6e53c",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Domain.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to invite guest users to the organization, without a signed-in user.",
+                "consentDisplayName":  "Invite guest users to the organization",
+                "id":  "09850681-111b-4a89-9bed-3f2cae46d706",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.Invite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read user's mailbox settings without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read all user mailbox settings",
+                "id":  "40f97065-369a-49f4-947c-6a255697ae91",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "MailboxSettings.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the memberships of hidden groups and administrative units without a signed-in user.",
+                "consentDisplayName":  "Read all hidden memberships",
+                "id":  "658aa5d8-239f-45c4-aa12-864f4fc7e490",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Member.Read.Hidden"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read mail in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read mail in all mailboxes",
+                "id":  "810c84a8-4a9e-49e6-bf7d-12d183f40d01",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete mail in all mailboxes without a signed-in user. Does not include permission to send mail.",
+                "consentDisplayName":  "Read and write mail in all mailboxes",
+                "id":  "e2a3a72e-5f79-4c64-b1b1-878b674786c9",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to send mail as any user without a signed-in user.",
+                "consentDisplayName":  "Send mail as any user",
+                "id":  "b633e1c5-b582-4048-a93e-9f11b44c7e96",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Mail.Send"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all contacts in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read contacts in all mailboxes",
+                "id":  "089fe4d0-434a-44c5-8827-41ba8a0b17f5",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Contacts.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete all contacts in all mailboxes without a signed-in user.",
+                "consentDisplayName":  "Read and write contacts in all mailboxes",
+                "id":  "6918b873-d17a-4dc1-b314-35f528134491",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Contacts.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read group properties and memberships, and read the calendar and conversations for all groups, without a signed-in user.",
+                "consentDisplayName":  "Read all groups",
+                "id":  "5b567255-7703-4780-807c-7be8301ae99b",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Group.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create groups, read all group properties and memberships, update group properties and memberships, and delete groups. Also allows the app to read and write group calendar and conversations.  All of these operations can be performed by the app without a signed-in user.",
+                "consentDisplayName":  "Read and write all groups",
+                "id":  "62a82d76-70ea-41e2-9197-370581804d09",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Group.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read data in your organization's directory, such as users, groups and apps, without a signed-in user.",
+                "consentDisplayName":  "Read directory data",
+                "id":  "7ab1d382-f21e-4acd-a863-ba3e13f7da61",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Directory.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write data in your organization's directory, such as users, and groups, without a signed-in user.  Does not allow user or group deletion.",
+                "consentDisplayName":  "Read and write directory data",
+                "id":  "19dbc75e-c2e2-444c-a770-ec69d8559fc7",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Directory.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and write all device properties without a signed in user.  Does not allow device creation, device deletion or update of device alternative security identifiers.",
+                "consentDisplayName":  "Read and write devices",
+                "id":  "1138cb37-bd11-4084-a2b7-9f71582aeddb",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Device.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read user profiles without a signed in user.",
+                "consentDisplayName":  "Read all users' full profiles",
+                "id":  "df021288-bdef-4463-88db-98f22de89214",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read and update user profiles without a signed in user.",
+                "consentDisplayName":  "Read and write all users' full profiles",
+                "id":  "741f803b-c850-494e-b5df-cde7c675a1ca",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "User.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read the identity risk event information for your organization without a signed in user.",
+                "consentDisplayName":  "Read all identity risk event information",
+                "id":  "6e472fd1-ad78-48da-a0f0-97ab2c6b769e",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "IdentityRiskEvent.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read events of all calendars without a signed-in user.",
+                "consentDisplayName":  "Read calendars in all mailboxes",
+                "id":  "798ee544-9d2d-430c-a058-570e29e34338",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calendars.Read"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create, read, update, and delete events of all calendars without a signed-in user.",
+                "consentDisplayName":  "Read and write calendars in all mailboxes",
+                "id":  "ef54d2bf-783f-4e0f-bca1-3210c0444d99",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Calendars.ReadWrite"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read, create, update and delete all files in all site collections without a signed in user. ",
+                "consentDisplayName":  "Read and write files in all site collections",
+                "id":  "75359482-378d-4052-8f01-80520e7db3cd",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Files.ReadWrite.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to read all files in all site collections without a signed in user.",
+                "consentDisplayName":  "Read files in all site collections",
+                "id":  "01d4889c-1287-42c6-ac1f-5d1e02578ef6",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Files.Read.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to create or delete document libraries and lists in all site collections without a signed in user.",
+                "consentDisplayName":  "Create, edit, and delete items and lists in all site collections",
+                "id":  "0c0bf378-bf22-4481-8f81-9e89a9b4960a",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.Manage.All"
+            },
+            {
+                "allowedMemberTypes":  [
+                                        "Application"
+                                    ],
+                "consentDescription":  "Allows the app to have full control of all site collections without a signed in user.",
+                "consentDisplayName":  "Have full control of all site collections",
+                "id":  "a82116e5-55eb-4c41-a434-62fe8a61c773",
+                "isEnabled":  true,
+                "isAdmin": false,
+                "value":  "Sites.FullControl.All"
+            }
+        ]
+}

--- a/PermissionsService.Test/TestFiles/appsettingstest-empty.json
+++ b/PermissionsService.Test/TestFiles/appsettingstest-empty.json
@@ -2,6 +2,7 @@
   "Permissions": {
     "FilePaths": [
       ".\\TestFiles\\permissions-test-file-v1.0_empty.json"
-    ]
+    ],
+    "ScopesInformationList": ".\\TestFiles\\ScopesInformationList-test-file.json"
   }
 }

--- a/PermissionsService.Test/TestFiles/appsettingstest-invalid.json
+++ b/PermissionsService.Test/TestFiles/appsettingstest-invalid.json
@@ -2,6 +2,7 @@
   "Permissions": {
     "FilePaths": [
       ".\\TestFiles\\incorrectly-named-file.json"
-    ]
+    ],
+    "ScopesInformationList": ".\\TestFiles\\ScopesInformationList-test-file.json"
   }
 }

--- a/PermissionsService.Test/TestFiles/appsettingstest-valid.json
+++ b/PermissionsService.Test/TestFiles/appsettingstest-valid.json
@@ -3,6 +3,7 @@
     "FilePaths": [
       ".\\TestFiles\\permissions-test-file-v1.0_ver1.json",
       ".\\TestFiles\\permissions-test-file-v1.0_ver2.json"
-    ]
+    ],
+    "ScopesInformationList": ".\\TestFiles\\ScopesInformationList-test-file.json"
   }
 }

--- a/PermissionsService.Test/TestFiles/permissions-test-file-v1.0_ver2.json
+++ b/PermissionsService.Test/TestFiles/permissions-test-file-v1.0_ver2.json
@@ -121,6 +121,20 @@
           "IdentityRiskEvent.Read.All"
         ]
       }
+    ],
+    "/lorem/ipsum/{id}": [
+      {
+        "HttpVerb": "GET",
+        "DelegatedWork": [
+          "LoremIpsum.Read.All",
+          "LoremIpsum.ReadWrite.All"
+        ],
+        "DelegatedPersonal": [],
+        "Application": [
+          "LoremIpsum.Read.All",
+          "LoremIpsum.ReadWrite.All"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Closes #135 

This PR proposes the following:
- Processing scopes information from a json file, storing this in-memory and looking up the relevant data for a particular scope for a given request, then dispatch out this info. back to the caller with all the relevant data.
- Modifying (and adding) tests to validate this feature.
- Adding the file containing the list of scopes information.

The returned data for a request like: 
`/api/GraphExplorerPermissions?requesturl=/me/memberof&method=GET&scopetype=DelegatedWork` 
would look something like:

`
[
  {
    "value":"Directory.Read.All",
    "consentDisplayName":"Read directory data",
    "consentDescription":"Allows the app to read data in your organization's directory.",
    "isAdmin":true
  },
  {
    "value":"Directory.ReadWrite.All",
    "consentDisplayName":"Read and write directory data",
    "consentDescription":"Allows the app to read and write data in your organization's directory, such as other users, groups.  It does not allow the app to delete users or groups, or reset user passwords.","isAdmin":true},{"value":"Directory.AccessAsUser.All","consentDisplayName":"Access the directory as you","consentDescription":"Allows the app to have the same access to information in your work or school directory as you do.",
    "isAdmin":true
    }
]
`