### PR TITLE
Add special properties starting with "@" to additionaldata

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -805,5 +805,45 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        // This tests asserts that a type beginning wirth "@" character is also added to the AdditionalData bag
+        public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            const string jsonObject = "{\r\n" +
+                                      "  \"name\": \"New Folder\",\r\n" +
+                                      "  \"folder\": { },\r\n" +
+                                      "  \"@microsoft.graph.conflictBehavior\": \"rename\"\r\n" +//to be added to the AdditionalData
+                                      "}";
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/drive/root/children")
+            {
+                Content = new StringContent(jsonObject)
+            };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var driveItem = new DriveItem\r\n" +
+                                           "{\r\n" +
+                                                "\tName = \"New Folder\",\r\n" +
+                                               "\tFolder = new Folder\r\n" +
+                                               "\t{\r\n" +
+                                               "\t},\r\n" +
+                                               "\tAdditionalData = new Dictionary<string, object>()\r\n" +
+                                               "\t{\r\n" +
+                                                    "\t\t{\"@microsoft.graph.conflictBehavior\",\"rename\"}\r\n" +
+                                               "\t}\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+                                           "await graphClient.Me.Drive.Root.Children\n" +
+                                               "\t.Request()\n" +
+                                               "\t.AddAsync(driveItem);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -807,7 +807,7 @@ namespace CodeSnippetsReflection.Test
         }
 
         [Fact]
-        // This tests asserts that a type beginning wirth "@" character is also added to the AdditionalData bag
+        // This tests asserts that a type beginning with "@" character is also added to the AdditionalData bag
         public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
         {
             //Arrange

--- a/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
@@ -443,7 +443,7 @@ namespace CodeSnippetsReflection.Test
         }
 
         [Fact]
-        // This tests asserts that a type beginning wirth "@" character is also added to the AdditionalData bag
+        // This tests asserts that a type beginning with "@" character is also added to the AdditionalData bag
         public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
         {
             //Arrange

--- a/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Xml;
 using CodeSnippetsReflection.LanguageGenerators;
@@ -442,5 +442,39 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
 
+        [Fact]
+        // This tests asserts that a type beginning wirth "@" character is also added to the AdditionalData bag
+        public void GeneratesSnippetsWithTypesStartingWithTheAtSymbol()
+        {
+            //Arrange
+            LanguageExpressions expressions = new JavaExpressions();
+            const string jsonObject = "{\r\n" +
+                                      "  \"name\": \"New Folder\",\r\n" +
+                                      "  \"folder\": { },\r\n" +
+                                      "  \"@microsoft.graph.conflictBehavior\": \"rename\"\r\n" + //to be added to the AdditionalData
+                                      "}";
+            var requestPayload =
+                new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/drive/root/children")
+                {
+                    Content = new StringContent(jsonObject)
+                };
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            //Act by generating the code snippet
+            var result = JavaGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "DriveItem driveItem = new DriveItem();\r\n" +
+                                           "driveItem.name = \"New Folder\";\r\n" +
+                                           "Folder folder = new Folder();\r\n" +
+                                           "driveItem.folder = folder;\r\n" +
+                                           "driveItem.additionalDataManager().put(\"@microsoft.graph.conflictBehavior\", new JsonPrimitive(\"rename\"));\r\n" +
+                                           "\r\n" +
+                                           "graphClient.me().drive().root().children()\n" +
+                                                "\t.buildRequest()\n" +
+                                                "\t.post(driveItem);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -251,9 +251,9 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         {
                             var value = JsonConvert.SerializeObject(jToken);
                             var newPath = path.Append(key).ToList();//add new identifier to the path
-                            if (key.Contains("@odata"))
+                            if (key.Contains("@odata") || key.StartsWith("@"))//sometimes @odata maybe in the middle e.g."invoiceStatus@odata.type"
                             {
-                                stringBuilder = GenerateCSharpOdataSection(stringBuilder, key, jToken.Value<string>(), className, tabSpace);
+                                stringBuilder = GenerateCSharpAdditionalDataSection(stringBuilder, key, jToken.Value<string>(), className, tabSpace);
                                 continue;
                             }
                             switch (jToken.Type)
@@ -336,7 +336,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         }
 
         /// <summary>
-        /// Generates language specific code relate to various odata properties
+        /// Generates language specific code relate to add special properties to the AdditionalData dictionary
         /// </summary>
         /// <param name="stringBuilder">The original string builder containing code generated so far</param>
         /// <param name="key">The odata key/property</param>
@@ -344,7 +344,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <param name="className">The class name for the entity needing modification</param>
         /// <param name="tabSpace">Tab space to use for formatting the code generated</param>
         /// <returns>a string builder with the relevant odata code added</returns>
-        private static StringBuilder GenerateCSharpOdataSection(StringBuilder stringBuilder, string key, string value, string className, string tabSpace)
+        private static StringBuilder GenerateCSharpAdditionalDataSection(StringBuilder stringBuilder, string key, string value, string className, string tabSpace)
         {
             switch (key)
             {

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -336,7 +336,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         }
 
         /// <summary>
-        /// Generates language specific code relate to add special properties to the AdditionalData dictionary
+        /// Generates language specific code to add special properties to the AdditionalData dictionary
         /// </summary>
         /// <param name="stringBuilder">The original string builder containing code generated so far</param>
         /// <param name="key">The odata key/property</param>

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -265,7 +265,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
 
         /// <summary>
-        /// Generates language specific code relate to add special properties to the AdditionalData dictionary
+        /// Generates language specific code to add special properties to the AdditionalData dictionary
         /// </summary>
         /// <param name="stringBuilder">The original string builder containing code generated so far</param>
         /// <param name="key">The odata key/property</param>

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -181,9 +181,9 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             var value = JsonConvert.SerializeObject(jToken);
                             var newPath = path.Append(key).ToList();//add new identifier to the path
                             
-                            if (key.Contains("@odata"))
+                            if (key.Contains("@odata") || key.StartsWith("@"))//sometimes @odata maybe in the middle e.g."invoiceStatus@odata.type"
                             {
-                                stringBuilder = GenerateJavaOdataSection(stringBuilder, key, jToken.ToString(), className, currentVarName);
+                                stringBuilder = GenerateJavaAdditionalDataSection(stringBuilder, key, jToken.ToString(), className, currentVarName);
                                 continue;
                             }
                             switch (jToken.Type)
@@ -265,7 +265,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
 
         /// <summary>
-        /// Generates language specific code relate to various odata properties
+        /// Generates language specific code relate to add special properties to the AdditionalData dictionary
         /// </summary>
         /// <param name="stringBuilder">The original string builder containing code generated so far</param>
         /// <param name="key">The odata key/property</param>
@@ -273,7 +273,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <param name="className">The class name for the entity needing modification</param>
         /// <param name="currentVarName">The variable name of the current object in use </param>
         /// <returns>a string builder with the relevant odata code added</returns>
-        private static StringBuilder GenerateJavaOdataSection(StringBuilder stringBuilder, string key, string value, string className, string currentVarName)
+        private static StringBuilder GenerateJavaAdditionalDataSection(StringBuilder stringBuilder, string key, string value, string className, string currentVarName)
         {
             switch (key)
             {


### PR DESCRIPTION
This PR closes #145 

#### Change proposed

Snippets with properties starting with the '@' character should also be added to the Additional data bag.

Therefore the snippet at this [link ](https://docs.microsoft.com/en-us/graph/api/driveitem-post-children?view=graph-rest-1.0&tabs=csharp#request)should look like this

```cs

GraphServiceClient graphClient = new GraphServiceClient( authProvider );

var driveItem = new DriveItem
{
	Name = "New Folder",
	Folder = new Folder
	{
	},
	AdditionalData = new Dictionary<string, object>
	{
	    { "@microsoft.graph.conflictBehavior", "rename" }
	}
};

await graphClient.Me.Drive.Root.Children
	.Request()
	.AddAsync(driveItem);

```