### PR TITLE
Fixes duplicate instances of Getting Started sample query category on alphabetical ordering

### DIFF
--- a/GraphExplorerSamplesService/Services/SamplesService.cs
+++ b/GraphExplorerSamplesService/Services/SamplesService.cs
@@ -200,7 +200,7 @@ namespace GraphExplorerSamplesService.Services
         {
             List<SampleQueryModel> sortedSampleQueries = sampleQueries.SampleQueries
                 .OrderBy(s => s.Category)
-                .SkipWhile(s => s.Category == "Getting Started") // skipped, as it should always be the top-most sample query in the list
+                .Where(s => s.Category != "Getting Started") // skipped, as it should always be the top-most sample query in the list
                 .ToList();
 
             SampleQueriesList sortedSampleQueriesList = new SampleQueriesList();

--- a/SamplesService.Test/SamplesServiceShould.cs
+++ b/SamplesService.Test/SamplesServiceShould.cs
@@ -155,8 +155,9 @@ namespace SamplesService.Test
             SampleQueriesList sampleQueriesList = GraphExplorerSamplesService.Services.SamplesService.DeserializeSampleQueriesList(validJsonString);
 
             /* Assert that the sample queries are returned in alphabetical order of their category names (with 'Getting Started' at the top-most)
-             * and with all details correct */
+             * and with all details and count of items correct */
 
+            Assert.True(sampleQueriesList.SampleQueries.Count == 4);
             Assert.Collection(sampleQueriesList.SampleQueries,
                 item =>
                 {


### PR DESCRIPTION
Closes #163 
Related to #130 

Proposes:
- Fixing the LINQ query that arranges the sample query categories alphabetically, such that it avoids duplicating the _Getting Started_ category.
- Adding a test to check whether the count of items returned is equal to the actual count of items in json.