### PR TITLE
Refactors controllers and updates new routes

### DIFF
--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Route("permissions")]
     [ApiController]
     public class GraphExplorerPermissionsController : ControllerBase
     {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -23,7 +23,7 @@ namespace GraphWebApi.Controllers
             _permissionsStore = permissionsStore;
         }
 
-        // Gets the permission scopes for a request url
+        // Gets the permission scopes and info for a request url
         [HttpGet]
         [Produces("application/json")]
         public IActionResult GetPermissionScopes([FromQuery]string requestUrl, [FromQuery]string method = "GET", [FromQuery]string scopeType = "DelegatedWork")

--- a/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Options;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Route("samplesadmin")]
     [ApiController]
     public class GraphExplorerSamplesAdminController : ControllerBase
     {

--- a/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -108,7 +108,10 @@ namespace GraphWebApi.Controllers
                 // Extract the first user claim from the given categoryPolicy; this is what was added
                 UserClaim userClaim = categoryPolicy.UserClaims.First();
 
-                // Create the query Uri for the newly created sample query
+                // Fetch the category policy with the newly created user claim
+                categoryPolicy = updatedPoliciesList.CategoryPolicies.Find(x => x.CategoryName == categoryPolicy.CategoryName);
+
+                // Create the query Uri for the newly created user claim
                 string newUserClaimUri = string.Format("{0}://{1}{2}?userprincipalname={3}&categoryname={4}", 
                     Request.Scheme, Request.Host, Request.Path.Value, userClaim.UserPrincipalName, categoryPolicy.CategoryName);
 
@@ -148,6 +151,9 @@ namespace GraphWebApi.Controllers
                 string updatedPoliciesJson = SamplesPolicyService.SerializeSampleQueriesPolicies(updatedPoliciesList);
 
                 await _fileUtility.WriteToFile(updatedPoliciesJson, _policiesFilePathSource);
+
+                // Fetch the category policy with the updated user claim
+                categoryPolicy = updatedPoliciesList.CategoryPolicies.Find(x => x.CategoryName == categoryPolicy.CategoryName);
 
                 // Success; return the user claim in the category policy that was just updated
                 return Ok(categoryPolicy);

--- a/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
@@ -239,7 +239,7 @@ namespace GraphWebApi.Controllers
                 // Get the serialized JSON string of the list of policies
                 string policiesJson = SamplesPolicyService.SerializeSampleQueriesPolicies(policies);
 
-                // Save the document-readable JSON-styled string to the source file
+                // Save the JSON string to the source file
                 await _fileUtility.WriteToFile(policiesJson, _policiesFilePathSource);
 
                 // Return the list of policies

--- a/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesAdminController.cs
@@ -92,7 +92,7 @@ namespace GraphWebApi.Controllers
                 if (!isAdmin)
                 {
                     return new JsonResult($"{userPrincipalName} is not authorized to create the user claim.")
-                    { StatusCode = StatusCodes.Status401Unauthorized };
+                    { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 // Get the list of policies
@@ -136,7 +136,7 @@ namespace GraphWebApi.Controllers
                 if (!isAdmin)
                 {
                     return new JsonResult($"{userPrincipalName} is not authorized to update the user claim.")
-                    { StatusCode = StatusCodes.Status401Unauthorized };
+                    { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 // Get the list of policies
@@ -185,7 +185,7 @@ namespace GraphWebApi.Controllers
                 {
                     return new JsonResult(
                        $"{userPrincipalName} is not authorized to remove the user claim.")
-                    { StatusCode = StatusCodes.Status401Unauthorized };
+                    { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 if (string.IsNullOrEmpty(userPrincipalName) || string.IsNullOrEmpty(categoryName))

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -27,6 +27,7 @@ namespace GraphWebApi.Controllers
 
         // Gets the list of all sample queries
         [Route("api/[controller]")]
+        [Route("samples")]
         [Produces("application/json")]
         [HttpGet]
         public async Task<IActionResult> GetSampleQueriesListAsync(string search)
@@ -71,6 +72,7 @@ namespace GraphWebApi.Controllers
 
        // Gets a sample query from the list of sample queries by its id
        [Route("api/[controller]/{id}")]
+       [Route("samples/{id}")]
        [Produces("application/json")]
        [HttpGet]
         public async Task<IActionResult> GetSampleQueryByIdAsync(string id)
@@ -104,6 +106,7 @@ namespace GraphWebApi.Controllers
 
         // Updates a sample query given its id value
         [Route("api/[controller]/{id}")]
+        [Route("samples/{id}")]
         [Produces("application/json")]
         [HttpPut]
         [Authorize]
@@ -168,6 +171,7 @@ namespace GraphWebApi.Controllers
 
         // Adds a new sample query to the list of sample queries
         [Route("api/[controller]")]
+        [Route("samples")]
         [Produces("application/json")]
         [HttpPost]
         [Authorize]
@@ -220,6 +224,7 @@ namespace GraphWebApi.Controllers
 
         // Deletes a sample query of the provided id from the list of smaple queries
         [Route("api/[controller]/{id}")]
+        [Route("samples/{id}")]
         [Produces("application/json")]
         [HttpDelete]
         [Authorize]

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -152,7 +152,7 @@ namespace GraphWebApi.Controllers
                 // Get the serialized JSON string of this sample query
                 string updatedSampleQueriesJson = SamplesService.SerializeSampleQueriesList(updatedSampleQueriesList);
 
-                // Save the document-readable JSON-styled string to the source file
+                // Save the JSON string to the source file
                 await _fileUtility.WriteToFile(updatedSampleQueriesJson, _queriesFilePathSource);
 
                 // Success; return the sample query model object that was just updated
@@ -207,7 +207,7 @@ namespace GraphWebApi.Controllers
                 // Get the serialized JSON string of the sample query
                 string newSampleQueriesJson = SamplesService.SerializeSampleQueriesList(newSampleQueriesList);
 
-                // Save the document-readable JSON-styled string to the source file
+                // Save the JSON string to the source file
                 await _fileUtility.WriteToFile(newSampleQueriesJson, _queriesFilePathSource);
 
                 // Create the query Uri for the newly created sample query
@@ -270,7 +270,7 @@ namespace GraphWebApi.Controllers
                 // Get the serialized JSON string of the list of sample queries
                 string newSampleQueriesJson = SamplesService.SerializeSampleQueriesList(sampleQueriesList);
 
-                // Save the document-readable JSON-styled string to the source file
+                // Save the JSON string to the source file
                 await _fileUtility.WriteToFile(newSampleQueriesJson, _queriesFilePathSource);
                                 
                 // Success; no content to return
@@ -326,7 +326,7 @@ namespace GraphWebApi.Controllers
                 // Get the serialized JSON string of the list of policies
                 string policiesJson = SamplesPolicyService.SerializeSampleQueriesPolicies(policies);
 
-                // Save the document-readable JSON-styled string to the source file
+                // Save the JSON string to the source file
                 await _fileUtility.WriteToFile(policiesJson, _policiesFilePathSource);
 
                 // Return the list of policies

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -127,7 +127,7 @@ namespace GraphWebApi.Controllers
                 {
                     return new JsonResult(
                         $"{userPrincipalName} is not authorized to update the sample query. Category: '{categoryName}'")
-                    { StatusCode = StatusCodes.Status401Unauthorized };
+                    { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 // Get the list of sample queries
@@ -192,7 +192,7 @@ namespace GraphWebApi.Controllers
                 {
                     return new JsonResult(
                         $"{userPrincipalName} is not authorized to create the sample query. Category: '{categoryName}'")
-                        { StatusCode = StatusCodes.Status401Unauthorized };
+                        { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 // Get the list of sample queries
@@ -256,7 +256,7 @@ namespace GraphWebApi.Controllers
                 {
                     return new JsonResult(
                         $"{userPrincipalName} is not authorized to delete the sample query. Category: '{categoryName}'")
-                    { StatusCode = StatusCodes.Status401Unauthorized };
+                    { StatusCode = StatusCodes.Status403Forbidden };
                 }
 
                 if (sampleQueriesList.SampleQueries.Count == 0)

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -222,7 +222,7 @@ namespace GraphWebApi.Controllers
             }
         }
 
-        // Deletes a sample query of the provided id from the list of smaple queries
+        // Deletes a sample query of the provided id from the list of sample queries
         [Route("api/[controller]/{id}")]
         [Route("samples/{id}")]
         [Produces("application/json")]

--- a/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSnippetsController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Http;
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Http.Internal;
 namespace GraphWebApi.Controllers
 {
     [Route("api/[controller]")]
+    [Route("snippetgenerator")]
     [ApiController]
     public class GraphExplorerSnippetsController : ControllerBase
     {


### PR DESCRIPTION
Closes #165 

Proposes:
- Updating routes in accordance with the updated OpenApi spec. Refer to this PR that updates the OpenApi spec.: https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/155

Updated routes:
`/snippetgenerator` 
`/samples`
`/samples/{id}`
`/permissions`
`/samplesadmin`

- Refactoring `SamplesAdmin` controller methods - `CreateUserClaimAsync` and `UpdateUserClaimAsync` to return the affected `CategoryPolicies` object with the list of all the `UserClaims` containing the newly added or updated `UserClaim`.

- Updating the status codes of prohibited resource modification attempts accordingly from `401` to `403` in accordance with the OpenApi spec.. 
- Minor comment updates.