### PR TITLE
Fix for skip token handling in csharp snippets

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -845,5 +845,31 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        // This tests asserts that a skiptoken is added as a Query option
+        public void GeneratesSnippetsSkipTokenAddedAsQueryOptions()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/calendarView/delta?$skiptoken=R0usmcCM996atia_s");
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+            //Act by generating the code snippet
+            var result = CSharpGenerator.GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var queryOptions = new List<QueryOption>()\r\n" +
+                                           "{\r\n" +
+                                                "\tnew QueryOption(\"$skiptoken\", \"R0usmcCM996atia_s\")" +
+                                           "\r\n};\r\n" +
+                                           "\r\n" +
+                                           "await graphClient.Me.CalendarView\n" +
+                                                "\t.Delta()\n" +
+                                                "\t.Request()\n" +
+                                                "\t.PostAsync();";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
     }
 }

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -520,7 +520,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
         /// <param name="snippetModel">Snippet model built from the request</param>
         private static string GenerateCustomQuerySection(SnippetModel snippetModel)
         {
-            if (!snippetModel.CustomQueryOptions.Any())
+            if (!snippetModel.CustomQueryOptions.Any()
+            && string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
             {
                 return string.Empty;//nothing to do here
             }
@@ -532,6 +533,12 @@ namespace CodeSnippetsReflection.LanguageGenerators
             foreach (var (key, value) in snippetModel.CustomQueryOptions)
             {
                 stringBuilder.Append($"\tnew QueryOption(\"{key}\", \"{value}\"),\r\n");
+            }
+
+            //Append any skip token queries
+            if (!string.IsNullOrEmpty(snippetModel.ODataUri.SkipToken))
+            {
+                stringBuilder.Append($"\tnew QueryOption(\"$skiptoken\", \"{snippetModel.ODataUri.SkipToken}\"),\r\n");
             }
 
             stringBuilder.Remove(stringBuilder.Length - 3, 1);//remove the trailing comma
@@ -597,7 +604,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string SelectExpression => "\n\t.Select( e => new {{\n\t\t\t e.{0} \n\t\t\t }})"; 
         public override string OrderByExpression => "\n\t.OrderBy(\"{0}\")"; 
         public override string SkipExpression => "\n\t.Skip({0})"; 
-        public override string SkipTokenExpression => "\n\t.SkipToken(\"{0}\")"; 
+        public override string SkipTokenExpression => ""; 
         public override string TopExpression => "\n\t.Top({0})";
         public override string FilterExpressionDelimiter => ",";
         public override string SelectExpressionDelimiter => ",\n\t\t\t e.";


### PR DESCRIPTION
This PR fixes the handling of skiptoken handling in CS snippets.

Thefore a snippet generated with a skiptoken in the query url will result to a snippet as below.

```cs
var queryOptions = new List<QueryOption>()
{
    new QueryOption("$skiptoken", "R0usmci39OQxqJrxK4")
};

var delta = await graphClient.Me.CalendarView
    .Delta()
    .Request(queryOptions)
    .Header("Prefer","odata.track-changes")
    .GetAsync();
```

This is related to https://github.com/microsoftgraph/microsoft-graph-docs/issues/6936