### PR TITLE
Adding support for OpenApi doc. inline referencing

### DIFF
--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29025.244
@@ -20,6 +19,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PermissionsService.Test", "PermissionsService.Test\PermissionsService.Test.csproj", "{A8F6FD5F-2C15-442F-9170-91BBE2293520}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenAPIService", "OpenAPIService\OpenAPIService.csproj", "{308A9E8D-5D74-4AAA-9C01-F72053B47444}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OpenAPI.OData.Reader", "..\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj", "{6DCE270C-2E76-475F-964D-5D81BB9658E1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +64,10 @@ Global
 		{308A9E8D-5D74-4AAA-9C01-F72053B47444}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{308A9E8D-5D74-4AAA-9C01-F72053B47444}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{308A9E8D-5D74-4AAA-9C01-F72053B47444}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DCE270C-2E76-475F-964D-5D81BB9658E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DCE270C-2E76-475F-964D-5D81BB9658E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DCE270C-2E76-475F-964D-5D81BB9658E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DCE270C-2E76-475F-964D-5D81BB9658E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,9 +6,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.6.1" />
-    <PackageReference Include="Microsoft.OpenApi.OData" Version="1.0.1" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.1.4" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.0-preview" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj" />
   </ItemGroup>
 
 </Project>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -337,9 +337,12 @@ namespace OpenAPIService
         {
             // This method is only needed because the output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance.
             // So we write it out, and read it back in again to fix it up.
-            var sb = new StringBuilder();
-            document.SerializeAsV3(new OpenApiYamlWriter(new StringWriter(sb)));
-            var doc = new OpenApiStringReader().Read(sb.ToString(), out var diag);
+
+            var outputString = new StringWriter(CultureInfo.InvariantCulture);
+            var writer = new OpenApiYamlWriter(outputString, new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
+            document.SerializeAsV3(writer);
+            var doc = new OpenApiStringReader().Read(outputString.GetStringBuilder().ToString(), out var diag);
+            
             return doc;
         }
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Services;
@@ -9,13 +9,13 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using System.Threading.Tasks;
 using Microsoft.OpenApi.OData;
 using System.Collections.Concurrent;
 using Tavis.UriTemplates;
+using System.Globalization;
 
 namespace OpenAPIService
 {


### PR DESCRIPTION
Proposes

- Bumping up version of package Microsoft.OpenApi.Readers to 1.2.0-preview to add support for inline referencing of OpenApi doc.
- Adding direct reference to Microsoft.OpenApi.OData.Readers library so as:
to get the most recent bug fixes;
enable us get direct method reference in the Microsoft.OpenApi.OData.Readers library