### PR TITLE
Bumping up version of Microsoft.OpenApi.Readers to get latest bug fixes

### DIFF
--- a/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
+++ b/Microsoft.OpenApi.OData.Reader/Microsoft.OpenAPI.OData.Reader.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.6.1" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.0-preview" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.0-preview.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/OpenAPIService/OpenAPIService.csproj
+++ b/OpenAPIService/OpenAPIService.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.OData.Edm" Version="7.6.1" />
-    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.0-preview" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.2.0-preview.2" />
     <PackageReference Include="Tavis.UriTemplates" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #200 
Related to: https://github.com/microsoft/OpenAPI.NET/issues/464

Proposes:
- Bumping up the version of `Microsoft.OpenApi.Readers` lib to `1.2.0-preview.2` so as to get the bug fix that corrects serializing OpenAPI doc as V2.