### PR TITLE
Slice OpenAPI doc. for Graph Explorer Autocomplete

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -60,7 +60,7 @@ namespace GraphWebApi.Controllers
 
                 OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh, styleOptions);
 
-                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
+                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions, predicate);
 
                 subsetOpenApiDocument = OpenApiService.ApplyStyle(styleOptions, subsetOpenApiDocument);
 

--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -42,6 +42,9 @@ namespace OpenAPIService.Common
                 case OpenApiStyle.PowerShell:
                     SetPowerShellStyle();
                     break;
+                case OpenApiStyle.GEAutocomplete:
+                    SetGEAutocompleteStyle();
+                    break;
                 default:
                     break;
             }
@@ -71,6 +74,14 @@ namespace OpenAPIService.Common
             EnableDiscriminatorValue = true;
             EnableDerivedTypesReferencesForRequestBody = true;
             EnableDerivedTypesReferencesForResponses = true;
+        }
+
+        private void SetGEAutocompleteStyle()
+        {
+            OpenApiVersion = OpenApiVersion ?? Constants.OpenApiConstants.OpenApiVersion_2;
+            GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
+            OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Json;
+            InlineLocalReferences = true;
         }
     }
 }

--- a/OpenAPIService/ContentRemover.cs
+++ b/OpenAPIService/ContentRemover.cs
@@ -15,7 +15,7 @@ namespace OpenAPIService
     {       
         public override void Visit(OpenApiResponse response)
         {            
-            if (response.Content.Any() == true)
+            if (response.Content.Any())
             {
                 response.Content.Clear();
                 base.Visit(response);
@@ -24,7 +24,7 @@ namespace OpenAPIService
 
         public override void Visit(OpenApiRequestBody requestBody)
         {
-            if (requestBody.Content.Any() == true)
+            if (requestBody.Content.Any())
             {
                requestBody.Content.Clear();
                base.Visit(requestBody);

--- a/OpenAPIService/ContentRemover.cs
+++ b/OpenAPIService/ContentRemover.cs
@@ -8,6 +8,9 @@ using System.Linq;
 
 namespace OpenAPIService
 {
+    /// <summary>
+    /// Provides OpenApi visitor methods that traverse an OpenAPI document and clears the OpenApiResponse and OpenApiRequestBody Content property values.
+    /// </summary>
     internal class ContentRemover: OpenApiVisitorBase
     {       
         public override void Visit(OpenApiResponse response)

--- a/OpenAPIService/ContentRemover.cs
+++ b/OpenAPIService/ContentRemover.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
+
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Services;
+using System.Linq;
+
+namespace OpenAPIService
+{
+    internal class ContentRemover: OpenApiVisitorBase
+    {       
+        public override void Visit(OpenApiResponse response)
+        {            
+            if (response.Content.Any() == true)
+            {
+                response.Content.Clear();
+                base.Visit(response);
+            }
+        }
+
+        public override void Visit(OpenApiRequestBody requestBody)
+        {
+            if (requestBody.Content.Any() == true)
+            {
+               requestBody.Content.Clear();
+               base.Visit(requestBody);
+            }         
+        }
+    }
+}

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -401,12 +401,12 @@ namespace OpenAPIService
                 var walker = new OpenApiWalker(copy);
                 walker.Walk(target);
 
-                morestuff = Add(copy.Components, target.Components);
+                morestuff = AddReferences(copy.Components, target.Components);
                 
             } while (morestuff);
         }
 
-        private static bool Add(OpenApiComponents newComponents, OpenApiComponents target)
+        private static bool AddReferences(OpenApiComponents newComponents, OpenApiComponents target)
         {
             var moreStuff = false; 
             foreach (var item in newComponents.Schemas)
@@ -415,7 +415,6 @@ namespace OpenAPIService
                 {
                     moreStuff = true;
                     target.Schemas.Add(item);
-
                 }
             }
 

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -236,7 +236,7 @@ namespace OpenAPIService
 
             if (styleOptions.OpenApiFormat == Constants.OpenApiConstants.Format_Yaml)
             {
-                if (styleOptions.InlineLocalReferences == true)
+                if (styleOptions.InlineLocalReferences)
                 {
                     writer = new OpenApiYamlWriter(sr,
                         new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
@@ -248,7 +248,7 @@ namespace OpenAPIService
             }
             else // json
             {
-                if (styleOptions.InlineLocalReferences == true)
+                if (styleOptions.InlineLocalReferences)
                 {
                     writer = new OpenApiJsonWriter(sr,
                         new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -225,10 +225,8 @@ namespace OpenAPIService
         /// <summary>
         /// Create a representation of the OpenApiDocument to return from an API
         /// </summary>
-        /// <param name="subset">OpenAPI document</param>
-        /// <param name="openApiVersion"></param>
-        /// <param name="format">The format of the OpenAPI doc.</param>
-        /// <param name="style">The styling preference of the OpenAPI doc.</param>
+        /// <param name="subset">OpenAPI document.</param>
+        /// <param name="OpenApiStyleOptions">The modal object containing the required styling options.</param>
         /// <returns></returns>
         public static MemoryStream SerializeOpenApiDocument(OpenApiDocument subset, OpenApiStyleOptions styleOptions)
         {
@@ -236,16 +234,31 @@ namespace OpenAPIService
             var sr = new StreamWriter(stream);
             OpenApiWriterBase writer;
 
-            if (styleOptions.InlineLocalReferences == true)
+            if (styleOptions.OpenApiFormat == Constants.OpenApiConstants.Format_Yaml)
             {
-                writer = new OpenApiYamlWriter(sr,
+                if (styleOptions.InlineLocalReferences == true)
+                {
+                    writer = new OpenApiYamlWriter(sr,
                         new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
+                }
+                else
+                {
+                    writer = new OpenApiYamlWriter(sr);
+                }
             }
-            else
+            else // json
             {
-                writer = new OpenApiYamlWriter(sr);
+                if (styleOptions.InlineLocalReferences == true)
+                {
+                    writer = new OpenApiJsonWriter(sr,
+                        new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
+                }
+                else
+                {
+                    writer = new OpenApiJsonWriter(sr);
+                }
             }
-            
+
             if (styleOptions.OpenApiVersion == Constants.OpenApiConstants.OpenApiVersion_2)
             {
                 subset.SerializeAsV2(writer);

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -28,7 +28,8 @@ namespace OpenAPIService
     {
         PowerShell,
         PowerPlatform,
-        Plain
+        Plain,
+        GEAutocomplete
     }
        
     public class OpenApiService
@@ -96,6 +97,11 @@ namespace OpenAPIService
 
                 pathItem.Operations.Add((OperationType)result.CurrentKeys.Operation, result.Operation);
             }
+                        
+            if (styleOptions.Style == OpenApiStyle.GEAutocomplete)
+            {
+                RemoveContent(subset);
+            }          
 
             CopyReferences(subset);
 
@@ -229,31 +235,16 @@ namespace OpenAPIService
             var sr = new StreamWriter(stream);
             OpenApiWriterBase writer;
 
-            if (styleOptions.OpenApiFormat == Constants.OpenApiConstants.Format_Yaml)
+            if (styleOptions.InlineLocalReferences == true)
             {
-                if (styleOptions.Style == OpenApiStyle.PowerPlatform)
-                {
-                    writer = new OpenApiYamlWriter(sr,
+                writer = new OpenApiYamlWriter(sr,
                         new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
-                }
-                else
-                {
-                    writer = new OpenApiYamlWriter(sr);
-                }
             }
             else
             {
-                if (styleOptions.Style == OpenApiStyle.PowerPlatform)
-                {
-                    writer = new OpenApiJsonWriter(sr,
-                        new OpenApiWriterSettings { ReferenceInline = ReferenceInlineSetting.InlineLocalReferences });
-                }
-                else
-                {
-                    writer = new OpenApiJsonWriter(sr);
-                }
+                writer = new OpenApiYamlWriter(sr);
             }
-
+            
             if (styleOptions.OpenApiVersion == Constants.OpenApiConstants.OpenApiVersion_2)
             {
                 subset.SerializeAsV2(writer);
@@ -437,5 +428,12 @@ namespace OpenAPIService
             }
             return moreStuff;
         }
-   }
+
+        private static void RemoveContent(OpenApiDocument target)
+        {            
+            var copy = new ContentRemover();
+            var walker = new OpenApiWalker(copy);
+            walker.Walk(target);
+        }
+    }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -432,9 +432,9 @@ namespace OpenAPIService
         }
 
         private static void RemoveContent(OpenApiDocument target)
-        {            
-            var copy = new ContentRemover();
-            var walker = new OpenApiWalker(copy);
+        {
+            ContentRemover contentRemover = new ContentRemover();
+            OpenApiWalker walker = new OpenApiWalker(contentRemover);
             walker.Walk(target);
         }
     }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -41,7 +41,7 @@ namespace OpenAPIService
         /// <summary>
         /// Create partial document based on provided predicate
         /// </summary>
-        public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, string graphVersion, Func<OpenApiOperation, bool> predicate)
+        public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, OpenApiStyleOptions styleOptions, Func<OpenApiOperation, bool> predicate)
         {
 
             var subset = new OpenApiDocument
@@ -49,7 +49,7 @@ namespace OpenAPIService
                 Info = new OpenApiInfo()
                 {
                     Title = title,
-                    Version = graphVersion
+                    Version = styleOptions.GraphVersion
                 },
 
                 Components = new OpenApiComponents()
@@ -72,7 +72,7 @@ namespace OpenAPIService
 
             subset.SecurityRequirements.Add(new OpenApiSecurityRequirement() { { aadv2Scheme, new string[] { } } });
 
-            subset.Servers.Add(new OpenApiServer() { Description = "Core", Url = string.Format(Constants.GraphConstants.GraphUrl, graphVersion) });
+            subset.Servers.Add(new OpenApiServer() { Description = "Core", Url = string.Format(Constants.GraphConstants.GraphUrl, styleOptions.GraphVersion) });
 
             var results = FindOperations(source, predicate);
             foreach (var result in results)

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -100,6 +100,7 @@ namespace OpenAPIService
                         
             if (styleOptions.Style == OpenApiStyle.GEAutocomplete)
             {
+                // Content property and its schema $refs are unnecessary for autocomplete
                 RemoveContent(subset);
             }          
 
@@ -262,7 +263,8 @@ namespace OpenAPIService
         /// Get OpenApiDocument version of Microsoft Graph based on CSDL document 
         /// </summary>
         /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
-        /// <param name="forceRefresh">Don't read from in-memory cache</param>
+        /// <param name="forceRefresh">Don't read from in-memory cache.</param>
+        /// <param name="styleOptions">Optional modal object containing the required styling options.</param>
         /// <returns>Instance of an OpenApiDocument</returns>
         public static async Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh, OpenApiStyleOptions styleOptions = null)
         {


### PR DESCRIPTION
Closes #220 

Proposes:
- Adding a new `GEAutocomplete` `OpenApiStyle` that will be used to capture styling options for Graph Explorer autocomplete feature.
- Adding a `ContentRemover.cs` _visitor_ class that will traverse a given OpenAPI doc removing the `Content` properties of a `Response` and `RequestBody` which will remove the schema `$refs`. This is to enable trimming of the returned payload.