### PR TITLE
Turns off discriminator support for PowerShell

### DIFF
--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -71,9 +71,9 @@ namespace OpenAPIService.Common
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Yaml;
             EnablePagination = true;
-            EnableDiscriminatorValue = true;
-            EnableDerivedTypesReferencesForRequestBody = true;
-            EnableDerivedTypesReferencesForResponses = true;
+            EnableDiscriminatorValue = false;
+            EnableDerivedTypesReferencesForRequestBody = false;
+            EnableDerivedTypesReferencesForResponses = false;
         }
 
         private void SetGEAutocompleteStyle()


### PR DESCRIPTION
Closes #231 

Proposes:
- Turning off the below flags for PowerShell; since AutoRest fails with this support enabled in the OpenAPI spec.
```
EnableDiscriminatorValue = false;
EnableDerivedTypesReferencesForRequestBody = false;
EnableDerivedTypesReferencesForResponses = false;
```