### PR TITLE
Adds caching of samples and permissions files

### DIFF
--- a/FileService/Common/FileServiceHelper.cs
+++ b/FileService/Common/FileServiceHelper.cs
@@ -11,7 +11,9 @@ namespace FileService.Common
     /// Defines a static class that contains helper methods that handle common file operations.
     /// </summary>
     public static class FileServiceHelper
-    {        
+    {
+        private const int DefaultRefreshTimeInHours = 24;
+
         /// <summary>
         /// Retrieves the directory name and file name from a given file path source.
         /// </summary>
@@ -43,7 +45,7 @@ namespace FileService.Common
         /// <param name="localeCode">The language code of the desired file. If empty or null or unsupported, this default to 'en-US'.</param>
         /// <returns>A string path of the fully qualified file name including the container name prepended to the resolved localized file name.</returns>
         public static string GetLocalizedFilePathSource(string containerName, string defaultBlobName, string localeCode = null)
-        {            
+        {
             CheckArgumentNullOrEmpty(containerName, nameof(containerName));
             CheckArgumentNullOrEmpty(defaultBlobName, nameof(defaultBlobName));
 
@@ -80,13 +82,13 @@ namespace FileService.Common
 
                 if (defaultBlobName.IndexOf('.') > 0 && localeCode != "en-US")
                 {
-                    /* All localized files have a consistent structure, e.g. sample-queries_fr-FR.json 
+                    /* All localized files have a consistent structure, e.g. sample-queries_fr-FR.json
                        except for 'en-Us' --> sample-queries.json or permissions-v1.0.json */
 
                     string[] blobNameParts = defaultBlobName.Split('.');
                     defaultBlobName = $"{blobNameParts[0]}_{localeCode}.{blobNameParts[1]}";
                 }
-            }          
+            }
 
             return $"{containerName}{FileServiceConstants.DirectorySeparator}{defaultBlobName}";
         }
@@ -104,6 +106,17 @@ namespace FileService.Common
             }
 
             return;
+        }
+
+        /// <summary>
+        /// Gets the cache refresh time from a string value.
+        /// This defaults to the default constant value if the conversion fails.
+        /// </summary>
+        /// <param name="value">"The string value of the cache refresh time."</param>
+        /// <returns>"The file cache refresh time."</returns>
+        public static int GetFileCacheRefreshTime(string value)
+        {
+            return int.TryParse(value, out int newTime) ? newTime : DefaultRefreshTimeInHours;
         }
     }
 }

--- a/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
+++ b/GraphExplorerPermissionsService/GraphExplorerPermissionsService.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />

--- a/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
@@ -4,6 +4,7 @@
 
 using GraphExplorerPermissionsService.Models;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GraphExplorerPermissionsService.Interfaces
 {
@@ -12,6 +13,9 @@ namespace GraphExplorerPermissionsService.Interfaces
     /// </summary>
     public interface IPermissionsStore
     {
-        List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork", string localeCode = null, string requestUrl = null, string method = null);
+        Task<List<ScopeInformation>> GetScopesAsync(string scopeType = "DelegatedWork",
+                                                    string localeCode = null,
+                                                    string requestUrl = null,
+                                                    string method = null);
     }
 }

--- a/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
@@ -14,7 +14,7 @@ namespace GraphExplorerPermissionsService.Interfaces
     public interface IPermissionsStore
     {
         Task<List<ScopeInformation>> GetScopesAsync(string scopeType = "DelegatedWork",
-                                                    string localeCode = null,
+                                                    string locale = null,
                                                     string requestUrl = null,
                                                     string method = null);
     }

--- a/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
+++ b/GraphExplorerPermissionsService/Interfaces/IPermissionStore.cs
@@ -8,10 +8,10 @@ using System.Collections.Generic;
 namespace GraphExplorerPermissionsService.Interfaces
 {
     /// <summary>
-    /// Defines an interface that provides a method for fetching permission scopes.
+    /// Defines an interface that provides a method for fetching permissions scopes.
     /// </summary>
     public interface IPermissionsStore
     {
-        List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork", string requestUrl = null, string method = null, string localeCode = null);
+        List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork", string localeCode = null, string requestUrl = null, string method = null);
     }
 }

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -30,11 +30,12 @@ namespace GraphExplorerPermissionsService
         private readonly string _permissionsContainerName;
         private readonly List<string> _permissionsBlobNames;
         private readonly string _scopesInformation;
-        private const int RefreshTimeInDays = 1; // life span of the in-memory cache
+        private readonly int _defaultRefreshTimeInHours; // life span of the in-memory cache
         private const string LocaleCode = "en-US"; // default locale language
 
         public PermissionsStore(IFileUtility fileUtility, IConfiguration configuration, IMemoryCache permissionsCache)
         {
+            _defaultRefreshTimeInHours = FileServiceHelper.GetFileCacheRefreshTime(configuration["FileCacheRefreshTimeInHours"]);
             _permissionsCache = permissionsCache;
             _fileUtility = fileUtility;
             _permissionsContainerName = configuration["AzureBlobStorage:Containers:Permissions"];
@@ -136,7 +137,7 @@ namespace GraphExplorerPermissionsService
             bool refreshPermissionsTables = false;
             bool cacheState = _permissionsCache.GetOrCreate("PermissionsTablesState", entry =>
             {
-                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(RefreshTimeInDays);
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_defaultRefreshTimeInHours);
                 return refreshPermissionsTables = true;
             });
 

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -99,7 +99,7 @@ namespace GraphExplorerPermissionsService
         /// <summary>
         /// Populates the delegated and application scopes information table caches.
         /// </summary>
-        private async Task SeedScopesInfoTables(string locale = DefaultLocale)
+        private async Task SeedScopesInfoTablesAsync(string locale = DefaultLocale)
         {
             ScopesInformationList scopesInformationList = await _permissionsCache.GetOrCreateAsync($"ScopesInfoList_{locale}", async cacheEntry =>
             {
@@ -155,12 +155,14 @@ namespace GraphExplorerPermissionsService
         /// Retrieves permissions scopes.
         /// </summary>
         /// <param name="scopeType">The type of scope to be retrieved for the target request url.</param>
+        /// <param name="locale">The language code for the preferred localized file.</param>
         /// <param name="requestUrl">The target request url whose scopes are to be retrieved.</param>
         /// <param name="method">The target http verb of the request url whose scopes are to be retrieved.</param>
-        /// <param name="locale">The language code for the preferred localized file.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public async Task<List<ScopeInformation>> GetScopesAsync(string scopeType = "DelegatedWork", string locale = DefaultLocale,
-                                                string requestUrl = null, string method = null)
+        public async Task<List<ScopeInformation>> GetScopesAsync(string scopeType = "DelegatedWork",
+                                                                 string locale = DefaultLocale,
+                                                                 string requestUrl = null,
+                                                                 string method = null)
         {
             try
             {
@@ -181,7 +183,7 @@ namespace GraphExplorerPermissionsService
 
                 /* Ensure that the requested localized copy of permissions descriptions
                    is available in the cache. */
-                await SeedScopesInfoTables(locale);
+                await SeedScopesInfoTablesAsync(locale);
 
                 string[] scopes = null;
 

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -65,7 +65,9 @@ namespace GraphExplorerPermissionsService
 
                     if (permissionsObject.Count < 1)
                     {
-                        throw new InvalidOperationException($"The permissions data sources cannot be empty.");
+                        throw new InvalidOperationException($"The permissions data sources cannot be empty." +
+                            $"Check the source file or check whether the file path is properly set. File path: " +
+                            $"{relativePermissionPath}");
                     }
 
                     JToken apiPermissions = permissionsObject.First.First;
@@ -134,14 +136,14 @@ namespace GraphExplorerPermissionsService
         /// refresh time duration.</returns>
         private bool RefreshPermissionsTables()
         {
-            bool refreshPermissionsTables = false;
+            bool refreshed = false;
             bool cacheState = _permissionsCache.GetOrCreate("PermissionsTablesState", entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_defaultRefreshTimeInHours);
-                return refreshPermissionsTables = true;
+                return refreshed = true;
             });
 
-            return refreshPermissionsTables;
+            return refreshed;
         }
 
         /// <summary>

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -150,7 +150,7 @@ namespace GraphExplorerPermissionsService
         /// <param name="method">The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="localeCode">The language code for the preferred localized file.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork", string localeCode = LocaleCode,
+        public async Task<List<ScopeInformation>> GetScopesAsync(string scopeType = "DelegatedWork", string localeCode = LocaleCode,
                                                 string requestUrl = null, string method = null)
         {
             try

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -29,8 +29,8 @@ namespace GraphExplorerPermissionsService
         private readonly string _permissionsContainerName;
         private readonly List<string> _permissionsBlobNames;
         private readonly string _scopesInformation;
-        private static readonly int RefreshTimeInDays = 1; // life span of the in-memory cache
-        private const string LOCALE_CODE = "en-US"; // default locale language
+        private const int RefreshTimeInDays = 1; // life span of the in-memory cache
+        private const string LocaleCode = "en-US"; // default locale language
 
         public PermissionsStore(IFileUtility fileUtility, IConfiguration configuration, IMemoryCache permissionsCache)
         {
@@ -55,7 +55,7 @@ namespace GraphExplorerPermissionsService
             foreach (string permissionFilePath in _permissionsBlobNames)
             {
                 string relativePermissionPath = FileServiceHelper.GetLocalizedFilePathSource(_permissionsContainerName, permissionFilePath);
-                string jsonString =  _fileUtility.ReadFromFile(relativePermissionPath).GetAwaiter().GetResult();
+                string jsonString = _fileUtility.ReadFromFile(relativePermissionPath).GetAwaiter().GetResult();
 
                 if (!string.IsNullOrEmpty(jsonString))
                 {
@@ -91,7 +91,7 @@ namespace GraphExplorerPermissionsService
         /// <summary>
         /// Populates the delegated and application scopes information table caches.
         /// </summary>
-        private void SeedScopesInfoTables(string localeCode = LOCALE_CODE)
+        private void SeedScopesInfoTables(string localeCode = LocaleCode)
         {
             string scopesInfoJson = _permissionsCache.GetOrCreate($"ScopesInfoJson_{localeCode}", cacheEntry =>
              {
@@ -129,7 +129,8 @@ namespace GraphExplorerPermissionsService
         /// Determines whether the permissions tables need to be refreshed with new data based on the elapsed time
         /// duration since the previous refresh.
         /// </summary>
-        /// <returns>True or False based on whether the elapsed time duration is greater or less than the specified refresh time duration.</returns>
+        /// <returns>true or false based on whether the elapsed time duration is greater or less than the specified
+        /// refresh time duration.</returns>
         private bool RefreshPermissionsTables()
         {
             bool refreshPermissionsTables = false;
@@ -143,15 +144,15 @@ namespace GraphExplorerPermissionsService
         }
 
         /// <summary>
-        /// Retrieves permissions scopes
+        /// Retrieves permissions scopes.
         /// </summary>
         /// <param name="scopeType">The type of scope to be retrieved for the target request url.</param>
         /// <param name="requestUrl">The target request url whose scopes are to be retrieved.</param>
         /// <param name="method">The target http verb of the request url whose scopes are to be retrieved.</param>
         /// <param name="localeCode">The language code for the preferred localized file.</param>
         /// <returns>A list of scopes for the target request url given a http verb and type of scope.</returns>
-        public List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork",
-            string requestUrl = null, string method = null, string localeCode = LOCALE_CODE)
+        public List<ScopeInformation> GetScopes(string scopeType = "DelegatedWork", string localeCode = LocaleCode,
+                                                string requestUrl = null, string method = null)
         {
             try
             {

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -46,7 +46,7 @@ namespace GraphExplorerPermissionsService
         /// <summary>
         /// Populates the template table with the request urls and the scopes table with the permission scopes.
         /// </summary>
-        private async Task SeedPermissionsTables()
+        private void SeedPermissionsTables()
         {
             _urlTemplateTable = new UriTemplateTable();
             _scopesListTable = new Dictionary<int, object>();
@@ -57,7 +57,7 @@ namespace GraphExplorerPermissionsService
             foreach (string permissionFilePath in _permissionsBlobNames)
             {
                 string relativePermissionPath = FileServiceHelper.GetLocalizedFilePathSource(_permissionsContainerName, permissionFilePath);
-                string jsonString = await _fileUtility.ReadFromFile(relativePermissionPath);
+                string jsonString = _fileUtility.ReadFromFile(relativePermissionPath).GetAwaiter().GetResult();
 
                 if (!string.IsNullOrEmpty(jsonString))
                 {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GraphExplorerPermissionsService.Interfaces;
 using GraphExplorerPermissionsService.Models;
 using GraphWebApi.Common;
@@ -27,22 +28,17 @@ namespace GraphWebApi.Controllers
         // Gets the permissions scopes
         [HttpGet]
         [Produces("application/json")]
-        public IActionResult GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
-                                                 [FromQuery]string requestUrl = null,
-                                                 [FromQuery]string method = null)
+        public async Task<IActionResult> GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
+                                                             [FromQuery]string requestUrl = null,
+                                                             [FromQuery]string method = null)
         {
             try
             {
                 string localeCode = RequestHelper.GetPreferredLocaleLanguage(Request);
                 List<ScopeInformation> result = null;
-                result = _permissionsStore.GetScopes(scopeType, localeCode, requestUrl, method);
+                result = await _permissionsStore.GetScopesAsync(scopeType, localeCode, requestUrl, method);
 
-                if (result == null)
-                {
-                    return NotFound();
-                }
-
-                return Ok(result);
+                return result == null ? NotFound() : (IActionResult)Ok(result);
             }
             catch (InvalidOperationException invalidOpsException)
             {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -35,7 +35,7 @@ namespace GraphWebApi.Controllers
             {
                 string localeCode = RequestHelper.GetPreferredLocaleLanguage(Request);
                 List<ScopeInformation> result = null;
-                result = _permissionsStore.GetScopes(scopeType, requestUrl, method, localeCode);
+                result = _permissionsStore.GetScopes(scopeType, localeCode, requestUrl, method);
 
                 if (result == null)
                 {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using GraphExplorerPermissionsService.Interfaces;
 using GraphExplorerPermissionsService.Models;
 using GraphWebApi.Common;
@@ -27,22 +28,18 @@ namespace GraphWebApi.Controllers
         // Gets the permissions scopes
         [HttpGet]
         [Produces("application/json")]
-        public IActionResult GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
-                                                 [FromQuery]string requestUrl = null,
-                                                 [FromQuery]string method = null)
+        public async Task<IActionResult> GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
+                                                             [FromQuery]string requestUrl = null,
+                                                             [FromQuery]string method = null)
         {
             try
             {
                 string localeCode = RequestHelper.GetPreferredLocaleLanguage(Request);
+
                 List<ScopeInformation> result = null;
-                result = _permissionsStore.GetScopes(scopeType, localeCode, requestUrl, method);
+                result = await _permissionsStore.GetScopesAsync(scopeType, localeCode, requestUrl, method);
 
-                if (result == null)
-                {
-                    return NotFound();
-                }
-
-                return Ok(result);
+                return result == null ? NotFound() : (IActionResult)Ok(result);
             }
             catch (InvalidOperationException invalidOpsException)
             {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using GraphExplorerPermissionsService.Interfaces;
 using GraphExplorerPermissionsService.Models;
 using GraphWebApi.Common;
@@ -28,17 +27,22 @@ namespace GraphWebApi.Controllers
         // Gets the permissions scopes
         [HttpGet]
         [Produces("application/json")]
-        public async Task<IActionResult> GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
-                                                             [FromQuery]string requestUrl = null,
-                                                             [FromQuery]string method = null)
+        public IActionResult GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
+                                                 [FromQuery]string requestUrl = null,
+                                                 [FromQuery]string method = null)
         {
             try
             {
                 string localeCode = RequestHelper.GetPreferredLocaleLanguage(Request);
                 List<ScopeInformation> result = null;
-                result = await _permissionsStore.GetScopesAsync(scopeType, localeCode, requestUrl, method);
+                result = _permissionsStore.GetScopes(scopeType, localeCode, requestUrl, method);
 
-                return result == null ? NotFound() : (IActionResult)Ok(result);
+                if (result == null)
+                {
+                    return NotFound();
+                }
+
+                return Ok(result);
             }
             catch (InvalidOperationException invalidOpsException)
             {

--- a/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerPermissionsController.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -24,11 +24,11 @@ namespace GraphWebApi.Controllers
             _permissionsStore = permissionsStore;
         }
 
-        // Gets the permission scopes 
+        // Gets the permissions scopes
         [HttpGet]
         [Produces("application/json")]
-        public IActionResult GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork", 
-                                                 [FromQuery]string requestUrl = null, 
+        public IActionResult GetPermissionScopes([FromQuery]string scopeType = "DelegatedWork",
+                                                 [FromQuery]string requestUrl = null,
                                                  [FromQuery]string method = null)
         {
             try

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -29,7 +29,7 @@ namespace GraphWebApi.Controllers
         private readonly string _policiesFilePathSource;
         private readonly string _sampleQueriesContainerName;
         private readonly string _sampleQueriesBlobName;
-        private static readonly int RefreshTimeInDays = 1; // life span of the in-memory cache
+        private const int RefreshTimeInDays = 1; // life span of the in-memory cache
 
         public GraphExplorerSamplesController(IFileUtility fileUtility, IConfiguration configuration, IMemoryCache samplesCache)
         {

--- a/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
+++ b/GraphWebApi/Controllers/GraphExplorerSamplesController.cs
@@ -29,10 +29,11 @@ namespace GraphWebApi.Controllers
         private readonly string _policiesFilePathSource;
         private readonly string _sampleQueriesContainerName;
         private readonly string _sampleQueriesBlobName;
-        private const int RefreshTimeInDays = 1; // life span of the in-memory cache
+        private readonly int _defaultRefreshTimeInHours;
 
         public GraphExplorerSamplesController(IFileUtility fileUtility, IConfiguration configuration, IMemoryCache samplesCache)
         {
+            _defaultRefreshTimeInHours = FileServiceHelper.GetFileCacheRefreshTime(configuration["FileCacheRefreshTimeInHours"]);
             _fileUtility = fileUtility;
             _samplesCache = samplesCache;
             _policiesFilePathSource = configuration["Samples:SampleQueriesPoliciesFilePathName"]; // sets the path of the sample queries policies JSON file
@@ -55,7 +56,7 @@ namespace GraphWebApi.Controllers
                 // Fetch cached sample queries
                 SampleQueriesList sampleQueriesList = await _samplesCache.GetOrCreateAsync(localeCode, async cacheEntry =>
                 {
-                    cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(RefreshTimeInDays);
+                    cacheEntry.AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(_defaultRefreshTimeInHours);
                     return await FetchSampleQueriesListAsync(localeCode);
                 });
 

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -33,5 +33,5 @@
       }
     }
   },
-  "FileCacheRefreshTimeInHours": "12"
+  "FileCacheRefreshTimeInHours": "24"
 }

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -30,7 +30,8 @@
           "permissions-beta.json"
         ],
         "Descriptions": "permissions-descriptions.json"
-      }     
-    }    
-  }
+      }
+    }
+  },
+  "FileCacheRefreshTimeInHours": "12"
 }

--- a/PermissionsService.Test/PermissionsService.Test.csproj
+++ b/PermissionsService.Test/PermissionsService.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -45,6 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="MemoryCache.Testing.Moq" Version="1.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="moq" Version="4.13.0" />

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -246,7 +246,7 @@ namespace PermissionsService.Test
             List<ScopeInformation> result =
                 permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}",
                                                 method: "GET",
-                                                localeCode: "es-ES").GetAwaiter().GetResult();
+                                                locale: "es-ES").GetAwaiter().GetResult();
 
             // Assert
             Assert.Collection(result,

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -5,6 +5,8 @@
 using FileService.Interfaces;
 using GraphExplorerPermissionsService;
 using GraphExplorerPermissionsService.Models;
+using MemoryCache.Testing.Moq;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
@@ -30,7 +32,8 @@ namespace PermissionsService.Test
         public void GetRequiredPermissionScopesGivenAnExistingRequestUrl()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl:"/security/alerts/{alert_id}", method: "GET");
@@ -57,7 +60,8 @@ namespace PermissionsService.Test
         public void GetAllPermissionScopesGivenNoRequestUrl()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             List<ScopeInformation> result = permissionsStore.GetScopes();
@@ -70,7 +74,8 @@ namespace PermissionsService.Test
         public void ReturnNullGivenANonExistentRequestUrl()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl:"/foo/bar/{alert_id}", method: "GET"); // non-existent request url
@@ -83,7 +88,8 @@ namespace PermissionsService.Test
         public void ReturnNullGivenANonExistentHttpVerb()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}", method: "Foobar"); // non-existent http verb
@@ -96,10 +102,11 @@ namespace PermissionsService.Test
         public void ReturnNullGivenANonExistentScopeType()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = 
+            List<ScopeInformation> result =
                 permissionsStore.GetScopes(scopeType: "Foobar", requestUrl: "/security/alerts/{alert_id}", method: "PATCH"); // non-existent scope type
 
             // Assert that returned result is null
@@ -110,10 +117,11 @@ namespace PermissionsService.Test
         public void ReturnEmptyArrayForEmptyPermissionScopes()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act by requesting scopes for the 'DelegatedPersonal' scope type
-            List<ScopeInformation> result = 
+            List<ScopeInformation> result =
                 permissionsStore.GetScopes(scopeType: "DelegatedPersonal", requestUrl: "/security/alerts/{alert_id}", method: "GET");
 
             // Assert that returned result is empty
@@ -124,15 +132,16 @@ namespace PermissionsService.Test
         public void ReturnScopesForRequestUrlsInEitherPermissionFilesProvided()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             /* Act */
 
-            List<ScopeInformation> result1 = 
+            List<ScopeInformation> result1 =
                 permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/users/{id}/calendars/{id}", method: "GET"); // permission in ver1 doc.
-            List<ScopeInformation> result2 = 
+            List<ScopeInformation> result2 =
                 permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/anonymousipriskevents/{id}", method: "GET"); // permission in ver2 doc.
-            List<ScopeInformation> result3 = 
+            List<ScopeInformation> result3 =
                 permissionsStore.GetScopes(scopeType: "Application", requestUrl: "/security/alerts/{id}", method: "PATCH"); // permission in ver1 doc.
 
             /* Assert */
@@ -169,11 +178,12 @@ namespace PermissionsService.Test
         public void RemoveParameterParanthesesFromRequestUrlsDuringLoadingOfPermissionsFiles()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             // RequestUrl in permission file: "/workbook/worksheets/{id}/charts/{id}/image(width=640)"
-            List<ScopeInformation> result = 
+            List<ScopeInformation> result =
                 permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/workbook/worksheets/{id}/charts/{id}/image", method: "GET");
 
             /* Assert */
@@ -192,7 +202,8 @@ namespace PermissionsService.Test
         public void ReturnScopesForRequestUrlWhoseScopesInformationNotAvailable()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
             List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl: "/lorem/ipsum/{id}", method: "GET"); // bogus permission whose scopes info are unavailable
@@ -219,10 +230,11 @@ namespace PermissionsService.Test
         public void ReturnLocalizedPermissionsDescriptionsForSupportedLanguage()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = 
+            List<ScopeInformation> result =
                 permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}", method: "GET", localeCode: "es-ES");
 
             // Assert
@@ -244,30 +256,16 @@ namespace PermissionsService.Test
         }
 
         [Fact]
-        public void ThrowInvalidOperationExceptionIfTablesNotPopulatedDueToIncorrectPermissionsFilePathName()
-        {
-            /* Arrange */
-
-            IConfigurationRoot configuration = new ConfigurationBuilder()
-               .AddJsonFile(".\\TestFiles\\appsettingstest-invalid.json")
-               .Build();
-
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, configuration);
-
-            // Act and Assert
-            Assert.Throws<InvalidOperationException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));
-        }
-
-        [Fact]
         public void ThrowInvalidOperationExceptionIfTablesNotPopulatedDueToEmptyPermissionsFile()
         {
             /* Arrange */
 
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
             IConfigurationRoot configuration = new ConfigurationBuilder()
                 .AddJsonFile(".\\TestFiles\\appsettingstest-empty.json")
                 .Build();
 
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, configuration);
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, configuration, _permissionsCache);
 
             // Act and Assert
             Assert.Throws<InvalidOperationException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));
@@ -277,10 +275,11 @@ namespace PermissionsService.Test
         public void ThrowArgumentNullExceptionIfMethodIsNullOrEmptyAndRequestUrlHasValue()
         {
             // Arrange
-            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration);
+            IMemoryCache _permissionsCache = Create.MockedMemoryCache();
+            PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));           
+            Assert.Throws<ArgumentNullException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));
         }
     }
 }

--- a/PermissionsService.Test/PermissionsStoreShould.cs
+++ b/PermissionsService.Test/PermissionsStoreShould.cs
@@ -36,7 +36,8 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl:"/security/alerts/{alert_id}", method: "GET");
+            List<ScopeInformation> result = permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}", method: "GET")
+                                                            .GetAwaiter().GetResult();
 
             // Assert
             Assert.Collection(result,
@@ -64,7 +65,7 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = permissionsStore.GetScopes();
+            List<ScopeInformation> result = permissionsStore.GetScopesAsync().GetAwaiter().GetResult();
 
             // Assert
             Assert.NotEmpty(result);
@@ -78,7 +79,8 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl:"/foo/bar/{alert_id}", method: "GET"); // non-existent request url
+            List<ScopeInformation> result = permissionsStore.GetScopesAsync(requestUrl: "/foo/bar/{alert_id}", method: "GET") // non-existent request url
+                                                            .GetAwaiter().GetResult();
 
             // Assert that returned result is null
             Assert.Null(result);
@@ -92,7 +94,8 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}", method: "Foobar"); // non-existent http verb
+            List<ScopeInformation> result = permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}", method: "Foobar") // non-existent http verb
+                                                            .GetAwaiter().GetResult();
 
             // Assert that returned result is null
             Assert.Null(result);
@@ -107,7 +110,9 @@ namespace PermissionsService.Test
 
             // Act
             List<ScopeInformation> result =
-                permissionsStore.GetScopes(scopeType: "Foobar", requestUrl: "/security/alerts/{alert_id}", method: "PATCH"); // non-existent scope type
+                permissionsStore.GetScopesAsync(scopeType: "Foobar",
+                                                requestUrl: "/security/alerts/{alert_id}",
+                                                method: "PATCH").GetAwaiter().GetResult(); // non-existent scope type
 
             // Assert that returned result is null
             Assert.Null(result);
@@ -122,7 +127,7 @@ namespace PermissionsService.Test
 
             // Act by requesting scopes for the 'DelegatedPersonal' scope type
             List<ScopeInformation> result =
-                permissionsStore.GetScopes(scopeType: "DelegatedPersonal", requestUrl: "/security/alerts/{alert_id}", method: "GET");
+                permissionsStore.GetScopesAsync(scopeType: "DelegatedPersonal", requestUrl: "/security/alerts/{alert_id}", method: "GET").GetAwaiter().GetResult();
 
             // Assert that returned result is empty
             Assert.Empty(result);
@@ -138,11 +143,11 @@ namespace PermissionsService.Test
             /* Act */
 
             List<ScopeInformation> result1 =
-                permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/users/{id}/calendars/{id}", method: "GET"); // permission in ver1 doc.
+                permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/users/{id}/calendars/{id}", method: "GET").GetAwaiter().GetResult(); // permission in ver1 doc.
             List<ScopeInformation> result2 =
-                permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/anonymousipriskevents/{id}", method: "GET"); // permission in ver2 doc.
+                permissionsStore.GetScopesAsync(scopeType: "DelegatedWork", requestUrl: "/anonymousipriskevents/{id}", method: "GET").GetAwaiter().GetResult(); // permission in ver2 doc.
             List<ScopeInformation> result3 =
-                permissionsStore.GetScopes(scopeType: "Application", requestUrl: "/security/alerts/{id}", method: "PATCH"); // permission in ver1 doc.
+                permissionsStore.GetScopesAsync(scopeType: "Application", requestUrl: "/security/alerts/{id}", method: "PATCH").GetAwaiter().GetResult(); // permission in ver1 doc.
 
             /* Assert */
 
@@ -184,7 +189,9 @@ namespace PermissionsService.Test
             // Act
             // RequestUrl in permission file: "/workbook/worksheets/{id}/charts/{id}/image(width=640)"
             List<ScopeInformation> result =
-                permissionsStore.GetScopes(scopeType: "DelegatedWork", requestUrl: "/workbook/worksheets/{id}/charts/{id}/image", method: "GET");
+                permissionsStore.GetScopesAsync(scopeType: "DelegatedWork",
+                                                requestUrl: "/workbook/worksheets/{id}/charts/{id}/image",
+                                                method: "GET").GetAwaiter().GetResult();
 
             /* Assert */
 
@@ -206,7 +213,9 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act
-            List<ScopeInformation> result = permissionsStore.GetScopes(requestUrl: "/lorem/ipsum/{id}", method: "GET"); // bogus permission whose scopes info are unavailable
+            List<ScopeInformation> result =
+                permissionsStore.GetScopesAsync(requestUrl: "/lorem/ipsum/{id}",
+                                                method: "GET").GetAwaiter().GetResult(); // bogus permission whose scopes info are unavailable
 
             // Assert
             Assert.Collection(result,
@@ -235,7 +244,9 @@ namespace PermissionsService.Test
 
             // Act
             List<ScopeInformation> result =
-                permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}", method: "GET", localeCode: "es-ES");
+                permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}",
+                                                method: "GET",
+                                                localeCode: "es-ES").GetAwaiter().GetResult();
 
             // Assert
             Assert.Collection(result,
@@ -268,7 +279,8 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, configuration, _permissionsCache);
 
             // Act and Assert
-            Assert.Throws<InvalidOperationException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));
+            Assert.Throws<InvalidOperationException>(() => permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}")
+                                                                           .GetAwaiter().GetResult());
         }
 
         [Fact]
@@ -279,7 +291,8 @@ namespace PermissionsService.Test
             PermissionsStore permissionsStore = new PermissionsStore(_fileUtility, _configuration, _permissionsCache);
 
             // Act and Assert
-            Assert.Throws<ArgumentNullException>(() => permissionsStore.GetScopes(requestUrl: "/security/alerts/{alert_id}"));
+            Assert.Throws<ArgumentNullException>(() => permissionsStore.GetScopesAsync(requestUrl: "/security/alerts/{alert_id}")
+                                                                       .GetAwaiter().GetResult());
         }
     }
 }


### PR DESCRIPTION
Closes #234 

Proposes:
- To improve performance, caching of samples and permissions files has been added. The cache will will be refreshed every 24 hours with new data.
- Refactoring the `PermissionsStore.cs` class in line with the intro. of the caching feature. 
- Updating the `Permissions.ServiceTest` project tests to add mocking support for the `IMemoryCache` and to remove redundant test.
- A few minor code refactorings.