### PR TITLE
Adds a root path to the OpenAPI description for GEAutocomplete

### DIFF
--- a/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
+++ b/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OpenApi.OData.Generator
                     Operations = new Dictionary<OperationType, OpenApiOperation> {
                         {
                             OperationType.Get, new OpenApiOperation {
-                                OperationId = "root.GetRoot",
+                                OperationId = "graphService.GetGraphService",
                                 Responses = new OpenApiResponses()
                                 {
                                     { "200",new OpenApiResponse() {

--- a/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
+++ b/Microsoft.OpenApi.OData.Reader/Generator/OpenApiPathItemGenerator.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 using System.Collections.Generic;
+using Microsoft.OData.Edm;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData.Common;
 using Microsoft.OpenApi.OData.Edm;
@@ -44,7 +45,40 @@ namespace Microsoft.OpenApi.OData.Generator
                 pathItems.Add(path.GetPathItemName(settings), handler.CreatePathItem(context, path));
             }
 
+            if (settings.ShowRootPath)
+            {
+                OpenApiPathItem rootPath = new OpenApiPathItem()
+                {
+                    Operations = new Dictionary<OperationType, OpenApiOperation> {
+                        {
+                            OperationType.Get, new OpenApiOperation {
+                                OperationId = "root.GetRoot",
+                                Responses = new OpenApiResponses()
+                                {
+                                    { "200",new OpenApiResponse() {
+                                        Description = "OK",
+                                        Links = CreateRootLinks(context.EntityContainer)
+                                    }
+                                }
+                            }
+                          }
+                        }
+                    }
+                };
+                pathItems.Add("/", rootPath);
+            }
+
             return pathItems;
+        }
+
+        private static IDictionary<string, OpenApiLink> CreateRootLinks(IEdmEntityContainer entityContainer)
+        {
+            var links = new Dictionary<string, OpenApiLink>();
+            foreach (var element in entityContainer.Elements)
+            {
+                links.Add(element.Name, new OpenApiLink());
+            }
+            return links;
         }
     }
 }

--- a/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -115,6 +115,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool EnableDerivedTypesReferencesForRequestBody { get; set; } = false;
 
+        /// <summary>
+        /// Gets/Sets a value indicating whether or not to show the root path of the described API.
+        /// </summary>
+        public bool ShowRootPath { get; set; } = false;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -138,7 +143,8 @@ namespace Microsoft.OpenApi.OData
                 PageableOperationName = this.PageableOperationName,
                 EnableDiscriminatorValue = this.EnableDiscriminatorValue,
                 EnableDerivedTypesReferencesForResponses = this.EnableDerivedTypesReferencesForResponses,
-                EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody
+                EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody,
+                ShowRootPath = this.ShowRootPath
             };
 
             return newSettings;

--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -18,6 +18,7 @@ namespace OpenAPIService.Common
         public bool EnableDiscriminatorValue { get; private set; } = false;
         public bool EnableDerivedTypesReferencesForRequestBody { get; private set; } = false;
         public bool EnableDerivedTypesReferencesForResponses { get; private set; } = false;
+        public bool ShowRootPath { get; set; } = false;
 
         public OpenApiStyleOptions(OpenApiStyle style, string openApiVersion = null, string graphVersion = null, string openApiFormat = null)
         {
@@ -82,6 +83,7 @@ namespace OpenAPIService.Common
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Json;
             InlineLocalReferences = true;
+            ShowRootPath = true;
         }
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -31,7 +31,7 @@ namespace OpenAPIService
         Plain,
         GEAutocomplete
     }
-       
+
     public class OpenApiService
     {
         private static ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<Uri, OpenApiDocument>();
@@ -97,12 +97,12 @@ namespace OpenAPIService
 
                 pathItem.Operations.Add((OperationType)result.CurrentKeys.Operation, result.Operation);
             }
-                        
+
             if (styleOptions.Style == OpenApiStyle.GEAutocomplete)
             {
                 // Content property and its schema $refs are unnecessary for autocomplete
                 RemoveContent(subset);
-            }          
+            }
 
             CopyReferences(subset);
 
@@ -118,11 +118,11 @@ namespace OpenAPIService
         /// <param name="graphVersion">Version of Microsoft Graph.</param>
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>
         /// <returns>A predicate</returns>
-        public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url, 
+        public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url,
             string graphVersion, bool forceRefresh)
          {
             if (operationIds != null && tags != null )
-            {  
+            {
                 return null; // Cannot filter by operationIds and tags at the same time
             }
             if (url != null && (operationIds != null || tags != null))
@@ -149,16 +149,16 @@ namespace OpenAPIService
                 if (tagsArray.Length == 1)
                 {
                     var regex = new Regex(tagsArray[0]);
-                    
+
                     predicate = (o) => o.Tags.Any(t => regex.IsMatch(t.Name));
-                } 
+                }
                 else
                 {
                     predicate = (o) => o.Tags.Any(t => tagsArray.Contains(t.Name));
                 }
             }
             else if (url != null)
-            {                
+            {
                 /* Extract the respective Operation Id(s) that match the provided url path */
 
                 if (!_openApiOperationsTable.Any() || forceRefresh)
@@ -194,7 +194,7 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// Populates the _uriTemplateTable with the Graph url paths and the _openApiOperationsTable 
+        /// Populates the _uriTemplateTable with the Graph url paths and the _openApiOperationsTable
         /// with the respective OpenApiOperations for these urls paths.
         /// </summary>
         /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
@@ -273,7 +273,7 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document 
+        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document
         /// </summary>
         /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>
@@ -313,10 +313,10 @@ namespace OpenAPIService
             var anyOfRemover = new AnyOfRemover();
             var walker = new OpenApiWalker(anyOfRemover);
             walker.Walk(subsetOpenApiDocument);
-                        
+
             if (styleOptions.Style == OpenApiStyle.PowerShell)
             {
-                // Format the OperationId for Powershell cmdlet names generation 
+                // Format the OperationId for Powershell cmdlet names generation
                 var operationIdFormatter = new OperationIdPowershellFormatter();
                 walker = new OpenApiWalker(operationIdFormatter);
                 walker.Walk(subsetOpenApiDocument);
@@ -327,7 +327,7 @@ namespace OpenAPIService
                     subsetOpenApiDocument.Info.Version = "v1.0-" + version;
                 }
             }
-                        
+
             return subsetOpenApiDocument;
         }
 
@@ -357,7 +357,8 @@ namespace OpenAPIService
                 EnablePagination = styleOptions == null ? false : styleOptions.EnablePagination,
                 EnableDiscriminatorValue = styleOptions == null ? false : styleOptions.EnableDiscriminatorValue,
                 EnableDerivedTypesReferencesForRequestBody = styleOptions == null ? false : styleOptions.EnableDerivedTypesReferencesForRequestBody,
-                EnableDerivedTypesReferencesForResponses = styleOptions == null ? false : styleOptions.EnableDerivedTypesReferencesForResponses
+                EnableDerivedTypesReferencesForResponses = styleOptions == null ? false : styleOptions.EnableDerivedTypesReferencesForResponses,
+                ShowRootPath = styleOptions == null ? false : styleOptions.ShowRootPath
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 
@@ -365,12 +366,12 @@ namespace OpenAPIService
 
             return document;
         }
-        
+
         private static OpenApiDocument FixReferences(OpenApiDocument document)
         {
             // This method is only needed because the output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance.
             // So we write it out, and read it back in again to fix it up.
-           
+
             var sb = new StringBuilder();
             document.SerializeAsV3(new OpenApiYamlWriter(new StringWriter(sb)));
             var doc = new OpenApiStringReader().Read(sb.ToString(), out var diag);
@@ -408,13 +409,13 @@ namespace OpenAPIService
                 walker.Walk(target);
 
                 morestuff = AddReferences(copy.Components, target.Components);
-                
+
             } while (morestuff);
         }
 
         private static bool AddReferences(OpenApiComponents newComponents, OpenApiComponents target)
         {
-            var moreStuff = false; 
+            var moreStuff = false;
             foreach (var item in newComponents.Schemas)
             {
                 if (!target.Schemas.ContainsKey(item.Key))


### PR DESCRIPTION
Closes #239 

Proposes:
- Adding functionality for the root path that defines the OpenAPI Links to be used by Graph Explorer in exposing the endpoint capabilities for url value = "/".
- Adding this feature support for `style` = `GEAutocomplete`