### PR TITLE
Disambiguate class names that end with Request in snippet generation

### DIFF
--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -458,6 +458,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
                 case "@odata.type":
                     var proposedType = CommonGenerator.UppercaseFirstLetter(value.Split(".").Last());
+                    proposedType = proposedType.EndsWith("Request") ? proposedType + "Object" : proposedType; // disambiguate class names that end with Request
                     //check if the odata type specified is different
                     // maybe due to the declaration of a subclass of the type specified from the url.
                     if (!className.Equals(proposedType))

--- a/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
+++ b/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
@@ -9,7 +9,12 @@ namespace CodeSnippetsReflection.TypeProperties
         /// <summary>
         /// returns C# class name from graph type: microsoft.graph.data => Data
         /// </summary>
-        public string ClassName => CommonGenerator.UppercaseFirstLetter(EdmType.ToString().Split(".").Last());
+        public string ClassName {
+            get {
+                var className = CommonGenerator.UppercaseFirstLetter(EdmType.ToString().Split(".").Last());
+                return className.EndsWith("Request") ? className + "Object" : className; // disambiguate class names that end with Request
+            }
+        }
 
         /// <summary>
         /// Whether the type is open, i.e. supports arbitrary properties (which goes in AdditionalData dictionary in SDK)


### PR DESCRIPTION
SDK disambiguates entity names that end with `Request` by appending `Object` to the name. This PR applies the same logic in snippet generation.

[Diff for generated snippets](https://github.com/microsoftgraph/microsoft-graph-docs/compare/zengin/snippets-checkpoint...zengin/snippets-request-object)

Resolves 9 Beta, 4 V1 compilation issues.

#AB4756