### PR TITLE
Select statements are sent as query string parameters in SDK

### DIFF
--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -161,7 +161,7 @@ namespace CodeSnippetsReflection.Test
             var result = CommonGenerator.GenerateQuerySection(snippetModel, expressions);
 
             //Assert string is empty
-            Assert.Equal("\n\t.Select( e => new {\n\t\t\t e.displayName,\n\t\t\t e.givenName,\n\t\t\t e.postalCode \n\t\t\t })", result);
+            Assert.Equal("\n\t.Select(\"displayName,givenName,postalCode\")", result);
         }
 
         [Fact]

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -44,8 +44,6 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 snippetBuilder.Append("GraphServiceClient graphClient = new GraphServiceClient( authProvider );\r\n\r\n");
                 var segment = snippetModel.Segments.Last();
                 snippetModel.ResponseVariableName = CommonGenerator.EnsureVariableNameIsNotReserved(snippetModel.ResponseVariableName , languageExpressions);
-                //Csharp properties are uppercase so replace with list with uppercase version
-                snippetModel.SelectFieldList = snippetModel.SelectFieldList.Select(CommonGenerator.UppercaseFirstLetter).ToList();
                 var actions = CommonGenerator.GenerateQuerySection(snippetModel, languageExpressions);
 
                 //append any custom queries present
@@ -730,13 +728,13 @@ namespace CodeSnippetsReflection.LanguageGenerators
         public override string FilterExpression => "\n\t.Filter(\"{0}\")";
         public override string SearchExpression => "\n\t.Search(\"{0}\")";
         public override string ExpandExpression => "\n\t.Expand(\"{0}\")";
-        public override string SelectExpression => "\n\t.Select( e => new {{\n\t\t\t e.{0} \n\t\t\t }})";
+        public override string SelectExpression => "\n\t.Select(\"{0}\")";
         public override string OrderByExpression => "\n\t.OrderBy(\"{0}\")";
         public override string SkipExpression => "\n\t.Skip({0})";
         public override string SkipTokenExpression => "";
         public override string TopExpression => "\n\t.Top({0})";
         public override string FilterExpressionDelimiter => ",";
-        public override string SelectExpressionDelimiter => ",\n\t\t\t e.";
+        public override string SelectExpressionDelimiter => ",";
         public override string OrderByExpressionDelimiter => " ";
         public override string HeaderExpression => "\n\t.Header(\"{0}\",\"{1}\")";
 


### PR DESCRIPTION
SDK Select methods are setting query string parameters, so instead of lambda expressions to select fields, we should send selected fields as comma separated strings.

[Diff in generated snippets](https://github.com/microsoftgraph/microsoft-graph-docs/compare/zengin/snippets-checkpoint...zengin/snippets-select)

Fixes 7 Beta and 7 V1 C# snippet compilation issues.

[AB#4762](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4762)