### PR TITLE
Handle TypeSegment in URL

### DIFF
--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -206,6 +206,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         }
                         resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");
                         break;
+                    case TypeSegment _:
+                        break; // type segment is not part of the resource path.
                     default:
                         //its most likely just a resource so append it
                         resourcesPath.Append($".{CommonGenerator.UppercaseFirstLetter(item.Identifier)}");

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -77,9 +77,12 @@ namespace CodeSnippetsReflection
             {
                 return CommonGenerator.LowerCaseFirstLetter(edmNamedElement.Name);
             }
-            
+
             //its not a collection/or named type so the identifier can do
-            return CommonGenerator.LowerCaseFirstLetter(oDataPathSegment.Identifier);
+            var identifier = oDataPathSegment.Identifier.Contains(".")
+                ? oDataPathSegment.Identifier.Split(".").Last()
+                : oDataPathSegment.Identifier;
+            return CommonGenerator.LowerCaseFirstLetter(identifier);
         }
 
 
@@ -123,7 +126,7 @@ namespace CodeSnippetsReflection
                         {
                             ExpandFieldExpression = ExpandFieldExpression.Substring(0, index);
                         }
-                       
+
                         break;
                 }
             }


### PR DESCRIPTION
Example request:
`GET https://graph.microsoft.com/v1.0/directory/deletedItems/microsoft.graph.group`

[Corresponding failing compilation test in V1](https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=18500&view=ms.vss-test-web.build-test-results-tab&runId=1004530&resultId=100384&paneView=debug)

[Diff in snippet generation](https://github.com/microsoftgraph/microsoft-graph-docs/compare/zengin/snippets-json...zengin/snippets-type-in-url)

Fixes 3 Beta 1 V1 compilation tests.

[AB#4782](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4782)