### PR TITLE
Returns all and fixes rendering permissions

### DIFF
--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -254,8 +254,7 @@ namespace GraphExplorerPermissionsService
                     JArray resultValue = new JArray();
                     resultValue = (JArray)_scopesListTable[int.Parse(resultMatch.Key)];
 
-                    string[] scopes = null;
-                    scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == method)?
+                    var scopes = resultValue.FirstOrDefault(x => x.Value<string>("HttpVerb") == method)?
                         .SelectToken(scopeType)?
                         .Select(s => (string)s)
                         .ToArray();

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -115,7 +115,8 @@ namespace GraphExplorerPermissionsService
                      * instance of the localized permissions descriptions
                      * during the lock.
                      */
-                    if (_permissionsCache.Get($"ScopesInfoList_{locale}") == null)
+                    var seededScopesInfoDictionary = _permissionsCache.Get<IDictionary<string, IDictionary<string, ScopeInformation>>>($"ScopesInfoList_{locale}");
+                    if (seededScopesInfoDictionary == null)
                     {
                         var _delegatedScopesInfoTable = new Dictionary<string, ScopeInformation>();
                         var _applicationScopesInfoTable = new Dictionary<string, ScopeInformation>();
@@ -148,8 +149,9 @@ namespace GraphExplorerPermissionsService
                             { Application, _applicationScopesInfoTable }
                         };
                     }
-                    // Fetch the localized cached permissions descriptions already seeded
-                    return _permissionsCache.Get<IDictionary<string, IDictionary<string, ScopeInformation>>>($"ScopesInfoList_{locale}");
+                    /* Fetch the localized cached permissions descriptions
+                       already seeded by previous thread. */
+                    return seededScopesInfoDictionary;
                 }
             });
             return scopesInformationDictionary;
@@ -201,8 +203,8 @@ namespace GraphExplorerPermissionsService
                        Refresh tables only after the specified time duration has elapsed or no cached copy exists. */
                     lock (_permissionsLock)
                     {
-                        // Ensure permissions tables are seeded by only one executing thread,
-                        // once per refresh cycle.
+                        /* Ensure permissions tables are seeded by only one executing thread,
+                           once per refresh cycle. */
                         if (!_permissionsRefreshed)
                         {
                             SeedPermissionsTables();

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -100,6 +100,8 @@ namespace GraphExplorerPermissionsService
         /// <summary>
         /// Gets or creates the localized permissions descriptions from the cache.
         /// </summary>
+        /// <param name="locale">The locale of the permissions decriptions file.</param>
+        /// <returns>The localized instance of permissions descriptions.</returns>
         private async Task<IDictionary<string, IDictionary<string, ScopeInformation>>> GetOrCreatePermissionsDescriptionsAsync(string locale = DefaultLocale)
         {
             var scopesInformationDictionary = await _permissionsCache.GetOrCreateAsync($"ScopesInfoList_{locale}", async cacheEntry =>

--- a/GraphExplorerPermissionsService/Services/PermissionsStore.cs
+++ b/GraphExplorerPermissionsService/Services/PermissionsStore.cs
@@ -218,16 +218,22 @@ namespace GraphExplorerPermissionsService
 
                     if (scopeType.Contains(Delegated))
                     {
-                        foreach(var scopesInfo in scopesInformationDictionary[Delegated])
+                        if (scopesInformationDictionary.ContainsKey(Delegated))
                         {
-                            scopesListInfo.Add(scopesInfo.Value);
+                            foreach (var scopesInfo in scopesInformationDictionary[Delegated])
+                            {
+                                scopesListInfo.Add(scopesInfo.Value);
+                            }
                         }
                     }
                     else // Application scopes
                     {
-                        foreach (var scopesInfo in scopesInformationDictionary[Application])
+                        if (scopesInformationDictionary.ContainsKey(Application))
                         {
-                            scopesListInfo.Add(scopesInfo.Value);
+                            foreach (var scopesInfo in scopesInformationDictionary[Application])
+                            {
+                                scopesListInfo.Add(scopesInfo.Value);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Closes #262 #261

Proposes:
- Returning all the permissions definitions and descriptions defined in the `permissions-descriptions.json` file instead of fetching the permissions definitions from the request urls json file.
- Fixes the issue of inconsistent permissions rendering. Localized permissions descriptions are seeded by only one executing thread, and a `lock` is used to avoid collision. If a thread finally gets a hold of the released lock and attempts to seed an already seeded localized permissions descriptions list, it instead gets assigned the cached copy of the permissions descriptions that were added prior. 
