### PR TITLE
Use transformed metadata in snippet generation

### DIFF
--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -42,23 +42,8 @@ namespace CodeSnippetsReflection
             ServiceRootBeta = new Uri("https://graph.microsoft.com/beta");
 
             // use transformed metadata, fallback to original if there are any parsing errors
-            try
-            {
-                IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml")));
-            }
-            catch
-            {
-                IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootV1 + "/$metadata")));
-            }
-
-            try
-            {
-                IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml")));
-            }
-            catch
-            {
-                IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootBeta + "/$metadata")));
-            }
+            IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml")));
+            IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml")));
         }
 
         /// <summary>

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -41,7 +41,7 @@ namespace CodeSnippetsReflection
             ServiceRootV1 = new Uri("https://graph.microsoft.com/v1.0");
             ServiceRootBeta = new Uri("https://graph.microsoft.com/beta");
 
-            // use transformed metadata, fallback to original if there are any parsing errors
+            // use clean metadata
             IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml")));
             IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml")));
         }

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -41,8 +41,24 @@ namespace CodeSnippetsReflection
             ServiceRootV1 = new Uri("https://graph.microsoft.com/v1.0");
             ServiceRootBeta = new Uri("https://graph.microsoft.com/beta");
 
-            IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootV1 + "/$metadata")));
-            IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootBeta + "/$metadata")));
+            // use transformed metadata, fallback to original if there are any parsing errors
+            try
+            {
+                IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml")));
+            }
+            catch
+            {
+                IedmModelV1 = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootV1 + "/$metadata")));
+            }
+
+            try
+            {
+                IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create("https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_beta_metadata/cleanMetadataWithDescriptionsbeta.xml")));
+            }
+            catch
+            {
+                IedmModelBeta = new Lazy<IEdmModel>(() => CsdlReader.Parse(XmlReader.Create(ServiceRootBeta + "/$metadata")));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
SDK uses transformed metadata and snippet generation uses raw metadata. This causes discrepancies in parameter order.

Changed the url to clean (transformed) metadata and added fallback to original metadata in case any parsing errors occur.

@andrueastman, FYI once this gets checked in, you will observe a reordering of parameters for `accept`, `decline` and `tentativelyAccept` in the next snippets update. This is expected due to a rule in XSLT transform.

cc: @darrelmiller, @pixieofhugs

[AB#4973](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4973)