### PR TITLE
Fixes the OperationIDs of the OpenAPI Links (#274)

### DIFF
--- a/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
+++ b/Microsoft.OpenApi.OData.Reader/OpenApiConvertSettings.cs
@@ -120,6 +120,11 @@ namespace Microsoft.OpenApi.OData
         /// </summary>
         public bool ShowRootPath { get; set; } = false;
 
+        /// <summary>
+        /// Gets/Sets a value indicating whether or not to show the OpenAPI links in the responses.
+        /// </summary>
+        public bool ShowLinks { get; set; } = false;
+
         internal OpenApiConvertSettings Clone()
         {
             var newSettings = new OpenApiConvertSettings
@@ -144,7 +149,8 @@ namespace Microsoft.OpenApi.OData
                 EnableDiscriminatorValue = this.EnableDiscriminatorValue,
                 EnableDerivedTypesReferencesForResponses = this.EnableDerivedTypesReferencesForResponses,
                 EnableDerivedTypesReferencesForRequestBody = this.EnableDerivedTypesReferencesForRequestBody,
-                ShowRootPath = this.ShowRootPath
+                ShowRootPath = this.ShowRootPath,
+                ShowLinks = this.ShowLinks
             };
 
             return newSettings;

--- a/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
+++ b/Microsoft.OpenApi.OData.Reader/Operation/EntityGetOperationHandler.cs
@@ -64,10 +64,17 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetResponses(OpenApiOperation operation)
         {
             OpenApiSchema schema = null;
+            IDictionary<string, OpenApiLink> links = null;
 
             if (Context.Settings.EnableDerivedTypesReferencesForResponses)
             {
                 schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (Context.Settings.ShowLinks)
+            {
+                links = Context.CreateLinks(entityType: EntitySet.EntityType(), entityName: EntitySet.Name,
+                        entityKind: EntitySet.ContainerElementKind.ToString(), parameters: operation.Parameters);
             }
 
             if (schema == null)
@@ -99,7 +106,7 @@ namespace Microsoft.OpenApi.OData.Operation
                                 }
                             }
                         },
-                        Links = Context.CreateLinks(EntitySet.EntityType(), EntitySet.Name, EntitySet.ContainerElementKind.ToString(), operation.Parameters)
+                        Links = links
                     }
                 }
             };

--- a/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
+++ b/Microsoft.OpenApi.OData.Reader/Operation/EntitySetGetOperationHandler.cs
@@ -131,10 +131,18 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetResponses(OpenApiOperation operation)
         {
             OpenApiSchema schema = null;
+            IDictionary<string, OpenApiLink> links = null;
 
             if (Context.Settings.EnableDerivedTypesReferencesForResponses)
             {
                 schema = EdmModelHelper.GetDerivedTypesReferenceSchema(EntitySet.EntityType(), Context.Model);
+            }
+
+            if (Context.Settings.ShowLinks)
+            {
+                links = Context.CreateLinks(entityType: EntitySet.EntityType(), entityName: EntitySet.Name,
+                        entityKind: EntitySet.ContainerElementKind.ToString(), parameters: operation.Parameters,
+                        targetMultiplicity: true);
             }
 
             if (schema == null)
@@ -193,7 +201,7 @@ namespace Microsoft.OpenApi.OData.Operation
                                 }
                             }
                         },
-                        Links = Context.CreateLinks(EntitySet.EntityType(), EntitySet.Name, EntitySet.ContainerElementKind.ToString(), operation.Parameters, targetMultiplicity: true)
+                        Links = links
                     }
                 }
             };

--- a/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
+++ b/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyGetOperationHandler.cs
@@ -68,6 +68,7 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetResponses(OpenApiOperation operation)
         {
             OpenApiSchema schema = null;
+            IDictionary<string, OpenApiLink> links = null;
 
             if (Context.Settings.EnableDerivedTypesReferencesForResponses)
             {
@@ -88,6 +89,15 @@ namespace Microsoft.OpenApi.OData.Operation
 
             if (!LastSegmentIsKeySegment && NavigationProperty.TargetMultiplicity() == EdmMultiplicity.Many)
             {
+                if (Context.Settings.ShowLinks)
+                {
+                    string operationId = GetOperationId();
+
+                    links = Context.CreateLinks(entityType: NavigationProperty.ToEntityType(), entityName: NavigationProperty.Name,
+                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: operation.Parameters,
+                            navPropOperationId: operationId, targetMultiplicity: true);
+                }
+
                 var properties = new Dictionary<string, OpenApiSchema>
                 {
                     {
@@ -109,7 +119,7 @@ namespace Microsoft.OpenApi.OData.Operation
                             Type = "string"
                         });
                 }
-                
+
                 operation.Responses = new OpenApiResponses
                 {
                     {
@@ -132,14 +142,22 @@ namespace Microsoft.OpenApi.OData.Operation
                                     }
                                 }
                             },
-                            Links = Context.CreateLinks(NavigationProperty.ToEntityType(), NavigationProperty.Name, 
-                            NavigationProperty.PropertyKind.ToString(), operation.Parameters, NavigationProperty.DeclaringEntityType().Name, true)
+                            Links = links
                         }
                     }
                 };
             }
             else
             {
+                if (Context.Settings.ShowLinks)
+                {
+                    string operationId = GetOperationId();
+
+                    links = Context.CreateLinks(entityType: NavigationProperty.ToEntityType(), entityName: NavigationProperty.Name,
+                            entityKind: NavigationProperty.PropertyKind.ToString(), parameters: operation.Parameters,
+                            navPropOperationId: operationId);
+                }
+
                 operation.Responses = new OpenApiResponses
                 {
                     {
@@ -157,13 +175,12 @@ namespace Microsoft.OpenApi.OData.Operation
                                     }
                                 }
                             },
-                            Links = Context.CreateLinks(NavigationProperty.ToEntityType(), NavigationProperty.Name,
-                            NavigationProperty.PropertyKind.ToString(), operation.Parameters, NavigationProperty.DeclaringEntityType().Name)
+                            Links = links
                         }
                     }
                 };
             }
-            
+
             operation.Responses.Add(Constants.StatusCodeDefault, Constants.StatusCodeDefault.GetResponse());
 
             base.SetResponses(operation);

--- a/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
+++ b/Microsoft.OpenApi.OData.Reader/Operation/NavigationPropertyOperationHandler.cs
@@ -115,7 +115,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 }
             }
-            
+
             string name = string.Join(".", items);
             OpenApiTag tag = new OpenApiTag
             {
@@ -137,7 +137,7 @@ namespace Microsoft.OpenApi.OData.Operation
             base.SetExtensions(operation);
         }
 
-        protected string GetOperationId(string prefix)
+        protected string GetOperationId(string prefix = null)
         {
             IList<string> items = new List<string>
             {
@@ -152,7 +152,15 @@ namespace Microsoft.OpenApi.OData.Operation
                 {
                     if (segment == lastpath)
                     {
-                        items.Add(prefix + Utils.UpperFirstChar(npSegment.NavigationProperty.Name));
+                        if (prefix != null)
+                        {
+                            items.Add(prefix + Utils.UpperFirstChar(npSegment.NavigationProperty.Name));
+                        }
+                        else
+                        {
+                            items.Add(Utils.UpperFirstChar(npSegment.NavigationProperty.Name));
+                        }
+
                         break;
                     }
                     else

--- a/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
+++ b/Microsoft.OpenApi.OData.Reader/Operation/SingletonGetOperationHandler.cs
@@ -64,10 +64,17 @@ namespace Microsoft.OpenApi.OData.Operation
         protected override void SetResponses(OpenApiOperation operation)
         {
             OpenApiSchema schema = null;
+            IDictionary<string, OpenApiLink> links = null;
 
             if (Context.Settings.EnableDerivedTypesReferencesForResponses)
             {
                 schema = EdmModelHelper.GetDerivedTypesReferenceSchema(Singleton.EntityType(), Context.Model);
+            }
+
+            if (Context.Settings.ShowLinks)
+            {
+                links = Context.CreateLinks(entityType: Singleton.EntityType(), entityName: Singleton.Name,
+                        entityKind: Singleton.ContainerElementKind.ToString(), parameters: operation.Parameters);
             }
 
             if (schema == null)
@@ -81,7 +88,7 @@ namespace Microsoft.OpenApi.OData.Operation
                     }
                 };
             }
-            
+
             operation.Responses = new OpenApiResponses
             {
                 {
@@ -99,7 +106,7 @@ namespace Microsoft.OpenApi.OData.Operation
                                 }
                             }
                         },
-                        Links = Context.CreateLinks(Singleton.EntityType(), Singleton.Name, Singleton.ContainerElementKind.ToString(), operation.Parameters)
+                        Links = links
                     }
                 }
             };

--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -19,6 +19,7 @@ namespace OpenAPIService.Common
         public bool EnableDerivedTypesReferencesForRequestBody { get; private set; } = false;
         public bool EnableDerivedTypesReferencesForResponses { get; private set; } = false;
         public bool ShowRootPath { get; set; } = false;
+        public bool ShowLinks { get; set; } = false;
 
         public OpenApiStyleOptions(OpenApiStyle style, string openApiVersion = null, string graphVersion = null, string openApiFormat = null)
         {
@@ -84,6 +85,7 @@ namespace OpenAPIService.Common
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Json;
             InlineLocalReferences = true;
             ShowRootPath = true;
+            ShowLinks = true;
         }
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -364,7 +364,8 @@ namespace OpenAPIService
                 EnableDiscriminatorValue = styleOptions == null ? false : styleOptions.EnableDiscriminatorValue,
                 EnableDerivedTypesReferencesForRequestBody = styleOptions == null ? false : styleOptions.EnableDerivedTypesReferencesForRequestBody,
                 EnableDerivedTypesReferencesForResponses = styleOptions == null ? false : styleOptions.EnableDerivedTypesReferencesForResponses,
-                ShowRootPath = styleOptions == null ? false : styleOptions.ShowRootPath
+                ShowRootPath = styleOptions == null ? false : styleOptions.ShowRootPath,
+                ShowLinks = styleOptions == null ? false : styleOptions.ShowLinks
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 
@@ -471,10 +472,11 @@ namespace OpenAPIService
             var parameterTypes = new Dictionary<string, string>();
             foreach (var parameter in parameters)
             {
-                /* The type and format properties describe the data type of the function parameters.
-                 * For string data types the format property is usually undefined.
+                /* The Type and Format properties describe the data type of the function parameters.
+                 * For string data types the Format property is usually undefined.
                  */
-                if (string.IsNullOrEmpty(parameter.Schema.Format))
+                if (string.IsNullOrEmpty(parameter.Schema.Format) &&
+                    !string.IsNullOrEmpty(parameter.Schema.Type))
                 {
                     parameterTypes.Add(parameter.Name, parameter.Schema.Type);
                 }


### PR DESCRIPTION
* Updated PowerShell formatter to set additionalProperties

* Attempts to fix links

* Fix Operation IDs for Links to NavigationProperties; rename parameters

* Add settings to turn Links on or off

* Add Link setting checks

* Bug fix: Ensure we strictly filter for string types

* Add option for showing Links in OpenAPIStyle options

* Retrieve the appropriate NavigationProperty OperationId prefixes

* Revert "Updated PowerShell formatter to set additionalProperties"

This reverts commit 46d291a11f8e6dcb11cac1a449b1d481d6f2d630.

* Add ShowLink setting to OpenAPIService

Co-authored-by: Darrel Miller <darrel.miller@microsoft.com>
Co-authored-by: Irvine Sunday <v-irsund@microsoft.com>