### PR TITLE
Setup Application Insights for server-side telemetry

### DIFF
--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <DockerDefaultTargetOS>Windows</DockerDefaultTargetOS>
     <UserSecretsId>2c8c1580-cbe8-4155-ac1a-4304a0632b26</UserSecretsId>
+    <ApplicationInsightsResourceId>/subscriptions/68397ef5-9754-46e7-9572-9b15d12367f1/resourceGroups/Graph-Explorer-API/providers/microsoft.insights/components/Graph-Explorer-API-Insights</ApplicationInsightsResourceId>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,13 +37,20 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2105168" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GraphWebApi/Program.cs
+++ b/GraphWebApi/Program.cs
@@ -1,26 +1,54 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Mvc;
+using Serilog;
+using Serilog.Events;
+using Serilog.Sinks.SystemConsole.Themes;
+using Microsoft.Extensions.Hosting;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace GraphWebApi
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            var host = CreateWebHostBuilder(args).Build();
+            var telemetryConfiguration = host.Services.GetRequiredService<TelemetryConfiguration>();
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                .MinimumLevel.Override("System", LogEventLevel.Warning)
+                .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                .WriteTo.Console(
+                    outputTemplate:
+                    "[{Timestamp:HH:mm:ss} {Level}] {SourceContext}{NewLine}{Message:lj}{NewLine}{Exception}{NewLine}",
+                    theme: AnsiConsoleTheme.Literate)
+                .WriteTo.ApplicationInsights(telemetryConfiguration, TelemetryConverter.Events)
+                .CreateLogger();
+            try
+            {
+                Log.Information("Starting web host");
+                await host.RunAsync();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+                    .UseStartup<Startup>()
+                    .UseSerilog();
+
     }
 }

--- a/GraphWebApi/Properties/serviceDependencies.json
+++ b/GraphWebApi/Properties/serviceDependencies.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets"
+    },
+    "appInsights1": {
+      "type": "appInsights",
+      "connectionId": "APPINSIGHTS_INSTRUMENTATIONKEY"
+    }
+  }
+}

--- a/GraphWebApi/Properties/serviceDependencies.local.json
+++ b/GraphWebApi/Properties/serviceDependencies.local.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "secrets1": {
+      "type": "secrets.user"
+    },
+    "appInsights1": {
+      "resourceId": "/subscriptions/[parameters('subscriptionId')]/resourceGroups/[parameters('resourceGroup')]/providers/microsoft.insights/components/Graph-Explorer-API-Insights",
+      "type": "appInsights.azure",
+      "connectionId": "APPINSIGHTS_INSTRUMENTATIONKEY",
+      "secretStore": "LocalSecretsFile"
+    }
+  }
+}

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -57,10 +57,12 @@ namespace GraphWebApi
             services.AddSingleton<IPermissionsStore, PermissionsStore>();
             services.AddSingleton<ISamplesStore, SamplesStore>();
             services.Configure<SamplesAdministrators>(Configuration);
+
             #region AppInsights
 
             services.AddApplicationInsightsTelemetry(options =>
             {
+                options.InstrumentationKey = Configuration["ApplicationInsights:InstrumentationKey"];
                 options.RequestCollectionOptions.InjectResponseHeaders = true;
                 options.RequestCollectionOptions.TrackExceptions = true;
                 options.EnableAuthenticationTrackingJavaScript = true;
@@ -68,6 +70,7 @@ namespace GraphWebApi
                 options.EnableAdaptiveSampling = true;
                 options.EnableQuickPulseMetricStream = true;
                 options.EnableDebugLogger = true;
+               
             });
 
             if (!_env.IsDevelopment())

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -10,6 +10,10 @@
       "Default": "Warning"
     }
   },
+  "ApplicationInsights": {
+    "InstrumentationKey": "9a1442b6-0ca1-4827-90b5-812decbeaeba",
+    "AppInsightsApiKey": "ENTER_KEY_HERE"
+  },
   "AllowedHosts": "*",
   "GraphMetadata": {
     "V1.0": "https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/master/clean_v10_metadata/cleanMetadataWithDescriptionsv1.0.xml",

--- a/GraphWebApi/appsettings.json
+++ b/GraphWebApi/appsettings.json
@@ -11,7 +11,7 @@
     }
   },
   "ApplicationInsights": {
-    "InstrumentationKey": "9a1442b6-0ca1-4827-90b5-812decbeaeba",
+    "InstrumentationKey": "ENTER_KEY_HERE",
     "AppInsightsApiKey": "ENTER_KEY_HERE"
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
This PR captures configuring app insights and Serilog to monitor DevX API in order to collect server-side telemetry data including:
- failed requests
- server requests
- server response time
- Exceptions thrown when requests are sent to the API