### PR TITLE
Fix: Applies style appropriately on singleton OpenAPI document

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -50,7 +50,7 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    throw new ArgumentException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
                 OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
@@ -72,9 +72,13 @@ namespace GraphWebApi.Controllers
                     return new FileStreamResult(stream, "application/json");
                 }
             }
-            catch (ArgumentException ex)
+            catch (InvalidOperationException ex)
             {
                 return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
             }
             catch (Exception ex)
             {
@@ -103,7 +107,7 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    throw new ArgumentException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
                 OpenApiDocument source = OpenApiService.ConvertCsdlToOpenApi(Request.Body);
@@ -125,9 +129,13 @@ namespace GraphWebApi.Controllers
                     return new FileStreamResult(stream, "application/json");
                 }
             }
-            catch (ArgumentException ex)
+            catch (InvalidOperationException ex)
             {
                 return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
             }
             catch (Exception ex)
             {
@@ -151,7 +159,7 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    throw new ArgumentException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
                 var graphOpenApi = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
@@ -160,9 +168,13 @@ namespace GraphWebApi.Controllers
 
                 return new EmptyResult();
             }
-            catch (ArgumentException ex)
+            catch (InvalidOperationException ex)
             {
                 return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
             }
             catch (Exception ex)
             {

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -2,29 +2,24 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
-using Microsoft.OData.Edm.Csdl;
 using Microsoft.OpenApi.Models;
-using Microsoft.OpenApi.OData;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Writers;
 using System.Collections.Concurrent;
 using System.IO;
-using System.Text;
-using System.Xml.Linq;
 
 namespace OpenAPIService.Test
 {
     /// <summary>
-    /// Defines a Mock class that simulates creating an OpenAPI document.
+    /// Defines a Mock class that creates an OpenAPI document from a CSDL file.
     /// </summary>
     public static class OpenAPIDocumentCreatorMock
     {
         private static readonly ConcurrentDictionary<string, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<string, OpenApiDocument>();
 
         /// <summary>
-        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document
+        /// Gets an OpenAPI document version of Microsoft Graph based on CSDL document
+        /// from a dictionary cache or gets a new instance.
         /// </summary>
-        /// <param name="graphDocPath">The uri of the Microsoft Graph metadata doc.</param>
+        /// <param name="graphDocPath">The file path of the Microsoft Graph metadata doc.</param>
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>
         /// <returns>Instance of an OpenApiDocument</returns>
         public static OpenApiDocument GetGraphOpenApiDocument(string graphDocPath, bool forceRefresh)
@@ -45,7 +40,7 @@ namespace OpenAPIService.Test
         /// <param name="graphDocPath">The file path of the CSDL document location.</param>
         /// <param name="styleOptions">Optional parameter that defines the style
         /// options to be used in formatting the OpenAPI document.</param>
-        /// <returns></returns>
+        /// <returns>Instance of an OpenApiDocument</returns>
         private static OpenApiDocument CreateOpenApiDocument(string graphDocPath)
         {
             if (string.IsNullOrEmpty(graphDocPath))
@@ -56,41 +51,9 @@ namespace OpenAPIService.Test
             using StreamReader streamReader = new StreamReader(graphDocPath);
             Stream csdl = streamReader.BaseStream;
 
-            var edmModel = CsdlReader.Parse(XElement.Load(csdl).CreateReader());
-
-            var settings = new OpenApiConvertSettings()
-            {
-                EnableKeyAsSegment = true,
-                EnableOperationId = true,
-                PrefixEntityTypeNameBeforeKey = true,
-                TagDepth = 2,
-                EnablePagination = true,
-                EnableDiscriminatorValue = false,
-                EnableDerivedTypesReferencesForRequestBody = false,
-                EnableDerivedTypesReferencesForResponses = false,
-                ShowRootPath = true,
-                ShowLinks = true
-            };
-            OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
-
-            document = FixReferences(document);
+            OpenApiDocument document = OpenApiService.ConvertCsdlToOpenApi(csdl);
 
             return document;
-        }
-
-        /// <summary>
-        /// This method is only needed because the output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance.
-        /// So we write it out, and read it back in again to fix it up
-        /// </summary>
-        /// <param name="document">The OpenAPI document to be actioned.</param>
-        /// <returns></returns>
-        private static OpenApiDocument FixReferences(OpenApiDocument document)
-        {
-            var sb = new StringBuilder();
-            document.SerializeAsV3(new OpenApiYamlWriter(new StringWriter(sb)));
-            var doc = new OpenApiStringReader().Read(sb.ToString(), out _);
-
-            return doc;
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.OData.Edm.Csdl;
-using Microsoft.OpenApi.Models;
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.OData;
 using Microsoft.OpenApi.Readers;
 using Microsoft.OpenApi.Writers;
-using OpenAPIService.Common;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Text;
 using System.Xml.Linq;
@@ -19,21 +19,41 @@ namespace OpenAPIService.Test
     /// </summary>
     public static class OpenAPIDocumentCreatorMock
     {
+        private static readonly ConcurrentDictionary<string, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<string, OpenApiDocument>();
+
+        /// <summary>
+        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document
+        /// </summary>
+        /// <param name="graphDocPath">The uri of the Microsoft Graph metadata doc.</param>
+        /// <param name="forceRefresh">Don't read from in-memory cache.</param>
+        /// <returns>Instance of an OpenApiDocument</returns>
+        public static OpenApiDocument GetGraphOpenApiDocument(string graphDocPath, bool forceRefresh)
+        {
+            if (!forceRefresh && _OpenApiDocuments.TryGetValue(graphDocPath, out OpenApiDocument doc))
+            {
+                return doc;
+            }
+
+            OpenApiDocument source = CreateOpenApiDocument(graphDocPath);
+            _OpenApiDocuments[graphDocPath] = source;
+            return source;
+        }
+
         /// <summary>
         /// Creates an OpenAPI document from a CSDL document.
         /// </summary>
-        /// <param name="uri">The file path of the CSDL document location.</param>
+        /// <param name="graphDocPath">The file path of the CSDL document location.</param>
         /// <param name="styleOptions">Optional parameter that defines the style
         /// options to be used in formatting the OpenAPI document.</param>
         /// <returns></returns>
-        public static OpenApiDocument CreateOpenApiDocument(string uri, OpenApiStyleOptions styleOptions = null)
+        private static OpenApiDocument CreateOpenApiDocument(string graphDocPath)
         {
-            if (string.IsNullOrEmpty(uri))
+            if (string.IsNullOrEmpty(graphDocPath))
             {
                 return null;
             }
 
-            using StreamReader streamReader = new StreamReader(uri);
+            using StreamReader streamReader = new StreamReader(graphDocPath);
             Stream csdl = streamReader.BaseStream;
 
             var edmModel = CsdlReader.Parse(XElement.Load(csdl).CreateReader());
@@ -44,11 +64,12 @@ namespace OpenAPIService.Test
                 EnableOperationId = true,
                 PrefixEntityTypeNameBeforeKey = true,
                 TagDepth = 2,
-                EnablePagination = styleOptions != null && styleOptions.EnablePagination,
-                EnableDiscriminatorValue = styleOptions != null && styleOptions.EnableDiscriminatorValue,
-                EnableDerivedTypesReferencesForRequestBody = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForRequestBody,
-                EnableDerivedTypesReferencesForResponses = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForResponses,
-                ShowRootPath = styleOptions != null && styleOptions.ShowRootPath
+                EnablePagination = true,
+                EnableDiscriminatorValue = false,
+                EnableDerivedTypesReferencesForRequestBody = false,
+                EnableDerivedTypesReferencesForResponses = false,
+                ShowRootPath = true,
+                ShowLinks = true
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 

--- a/OpenAPIService.Test/OpenAPIService.Test.csproj
+++ b/OpenAPIService.Test/OpenAPIService.Test.csproj
@@ -14,10 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="TestFiles\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\OpenAPIService\OpenAPIService.csproj" />
   </ItemGroup>
 

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -3,7 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.OpenApi.Models;
-using OpenAPIService.Common;
+using System;
 using Xunit;
 
 namespace OpenAPIService.Test
@@ -12,12 +12,20 @@ namespace OpenAPIService.Test
     {
         private const string GraphBetaCsdl = ".\\TestFiles\\Graph.Beta.OData.xml";
         private const string Title = "Partial Graph API";
-        private readonly OpenApiDocument _source = null;
+        private const string GraphVersion = "beta";
+        private readonly OpenApiDocument _graphBetaSource = null;
 
         public OpenAPIServiceShould()
         {
             // Create OpenAPI document with default OpenApiStyle = Plain
-            _source = OpenAPIDocumentCreatorMock.CreateOpenApiDocument(GraphBetaCsdl);
+            _graphBetaSource = OpenAPIDocumentCreatorMock.GetGraphOpenApiDocument(GraphBetaCsdl, false);
+        }
+
+        [Fact]
+        public void ReturnAllPathsInGraphCsdl()
+        {
+            Assert.Equal(4586, _graphBetaSource.Paths.Count);
+            Assert.NotNull(_graphBetaSource.Paths["/"]); // root path
         }
 
         [Fact]
@@ -26,15 +34,17 @@ namespace OpenAPIService.Test
             // Arrange
             string operationId_1 = "reports.getTeamsUserActivityCounts";
             string operationId_2 = "reports.getTeamsUserActivityUserDetail-a3f1";
-            string graphVersion = "beta";
-            OpenApiDocument source = _source;
-            OpenApiStyleOptions styleOptions = new OpenApiStyleOptions(OpenApiStyle.PowerShell, graphVersion: graphVersion);
-            var predicate_1 = OpenApiService.CreatePredicate(operationId_1, null, null, source, false).GetAwaiter().GetResult();
-            var predicate_2 = OpenApiService.CreatePredicate(operationId_2, null, null, source, false).GetAwaiter().GetResult();
+            OpenApiDocument source = _graphBetaSource;
+
+            var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1, tags: null, url: null, source: source)
+                .GetAwaiter().GetResult();
+
+            var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2, tags: null, url: null, source: source)
+                .GetAwaiter().GetResult();
 
             // Act
-            var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, styleOptions, predicate_1);
-            var subsetOpenApiDocument_2 = OpenApiService.CreateFilteredDocument(source, Title, styleOptions, predicate_2);
+            var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
+            var subsetOpenApiDocument_2 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_2);
 
             // Assert
             Assert.Collection(subsetOpenApiDocument_1.Paths,
@@ -47,6 +57,163 @@ namespace OpenAPIService.Test
                {
                    Assert.Equal("/reports/microsoft.graph.getTeamsUserActivityUserDetail(date={date})", item.Key);
                });
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("users.user.ListUser", "users.user", "/users")]
+        [InlineData("users.user.ListUser", "users.user", null)]
+        [InlineData("users.user.ListUser", null, "/users")]
+        [InlineData(null, "users.user", "/users")]
+        public void ThrowsArgumentExceptionInCreatePredicateWhenInvalidArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act and Assert
+            if (string.IsNullOrEmpty(operationIds) &&
+                string.IsNullOrEmpty(tags) &&
+                string.IsNullOrEmpty(url))
+            {
+                Assert.Throws<ArgumentNullException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                .GetAwaiter().GetResult());
+            }
+            else
+            {
+                Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult());
+            }
+        }
+
+        [Fact]
+        public void ThrowsArgumentExceptionWhenInvalidUrlArgumentIsSpecified()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act and Assert
+            Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "foo", source: source)
+                                .GetAwaiter().GetResult());
+        }
+
+        [Theory]
+        [InlineData(null, null, "/users")]
+        [InlineData(null, "users.user", null)]
+        [InlineData("users.user.ListUser", null, null)]
+        public void ReturnValueInCreatePredicateWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            // Assert
+            Assert.NotNull(predicate);
+        }
+
+        [Theory]
+        [InlineData(null, null, "/users")]
+        [InlineData(null, "users.user", null)]
+        [InlineData("users.user.ListUser", null, null)]
+        public void ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            // Assert
+            Assert.NotNull(subsetOpenApiDocument);
+
+            if (!string.IsNullOrEmpty(operationIds))
+            {
+                Assert.Single(subsetOpenApiDocument.Paths);
+            }
+            else if (!string.IsNullOrEmpty(tags))
+            {
+                Assert.Equal(2, subsetOpenApiDocument.Paths.Count);
+            }
+            else // url
+            {
+                Assert.Single(subsetOpenApiDocument.Paths);
+            }
+        }
+
+        [Theory]
+        [InlineData(OpenApiStyle.Plain, "/users/{user-id}")]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}")]
+        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
+        [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
+        public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(style, subsetOpenApiDocument);
+
+            // Assert
+            if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
+            {
+                var content = subsetOpenApiDocument.Paths[url]
+                    .Operations[OperationType.Get].Responses["200"].Content;
+
+                Assert.Single(subsetOpenApiDocument.Paths);
+
+                if (style == OpenApiStyle.GEAutocomplete)
+                {
+                    Assert.Empty(content);
+                }
+                else // Plain
+                {
+                    Assert.NotEmpty(content);
+                }
+            }
+            else // PowerShell || PowerPlatform
+            {
+                var anyOf = subsetOpenApiDocument.Paths[url]
+                    .Operations[OperationType.Post].Responses["200"].Content["application/json"].Schema.AnyOf;
+
+                Assert.Null(anyOf);
+
+                if (style == OpenApiStyle.PowerShell)
+                {
+                    var newOperationId = subsetOpenApiDocument.Paths[url]
+                    .Operations[OperationType.Post].OperationId;
+
+                    Assert.Equal("administrativeUnits_restore", newOperationId);
+                }
+            }
+        }
+
+        [Fact]
+        public void RemoveRootPathFromOpenApiDocumentInApplyStyleForPowerShellOpenApiStyle()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: "*", tags: null, url: null, source: source)
+                                .GetAwaiter().GetResult(); // fetch all paths/operations
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+
+            // Assert
+            Assert.Equal(4585, subsetOpenApiDocument.Paths.Count);
+            Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -65,7 +65,7 @@ namespace OpenAPIService.Test
         [InlineData("users.user.ListUser", "users.user", null)]
         [InlineData("users.user.ListUser", null, "/users")]
         [InlineData(null, "users.user", "/users")]
-        public void ThrowsArgumentExceptionInCreatePredicateWhenInvalidArgumentsAreSpecified(string operationIds, string tags, string url)
+        public void ThrowsArgumentExceptionInCreatePredicateWhenInvalidNumberOfArgumentsAreSpecified(string operationIds, string tags, string url)
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;
@@ -86,7 +86,7 @@ namespace OpenAPIService.Test
         }
 
         [Fact]
-        public void ThrowsArgumentExceptionWhenInvalidUrlArgumentIsSpecified()
+        public void ThrowsArgumentExceptionInCreatePredicateWhenInvalidUrlArgumentIsSpecified()
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -22,10 +22,20 @@ namespace OpenAPIService.Test
         }
 
         [Fact]
-        public void ReturnAllPathsInGraphCsdl()
+        public void ReturnAllPathsInConvertCsdlToOpenApi()
         {
-            Assert.Equal(4586, _graphBetaSource.Paths.Count);
-            Assert.NotNull(_graphBetaSource.Paths["/"]); // root path
+            // Arrange
+            var rootPath = "/";
+            var pathsCount = 4586;
+            var linksCount = _graphBetaSource.Paths[rootPath]
+                                .Operations[OperationType.Get]
+                                .Responses["200"]
+                                .Links.Count;
+
+            // Assert
+            Assert.Equal(pathsCount, _graphBetaSource.Paths.Count);
+            Assert.NotNull(_graphBetaSource.Paths["/"]);
+            Assert.Equal(62, linksCount);
         }
 
         [Fact]
@@ -76,7 +86,7 @@ namespace OpenAPIService.Test
                 string.IsNullOrEmpty(url))
             {
                 Assert.Throws<ArgumentNullException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
-                .GetAwaiter().GetResult());
+                                .GetAwaiter().GetResult());
             }
             else
             {
@@ -167,7 +177,9 @@ namespace OpenAPIService.Test
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
             {
                 var content = subsetOpenApiDocument.Paths[url]
-                    .Operations[OperationType.Get].Responses["200"].Content;
+                                .Operations[OperationType.Get]
+                                .Responses["200"]
+                                .Content;
 
                 Assert.Single(subsetOpenApiDocument.Paths);
 
@@ -183,14 +195,19 @@ namespace OpenAPIService.Test
             else // PowerShell || PowerPlatform
             {
                 var anyOf = subsetOpenApiDocument.Paths[url]
-                    .Operations[OperationType.Post].Responses["200"].Content["application/json"].Schema.AnyOf;
+                                .Operations[OperationType.Post]
+                                .Responses["200"]
+                                .Content["application/json"]
+                                .Schema
+                                .AnyOf;
 
                 Assert.Null(anyOf);
 
                 if (style == OpenApiStyle.PowerShell)
                 {
                     var newOperationId = subsetOpenApiDocument.Paths[url]
-                    .Operations[OperationType.Post].OperationId;
+                                            .Operations[OperationType.Post]
+                                            .OperationId;
 
                     Assert.Equal("administrativeUnits_restore", newOperationId);
                 }

--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -14,12 +14,6 @@ namespace OpenAPIService.Common
         public string GraphVersion { get; private set; }
         public string OpenApiFormat { get; private set; }
         public bool InlineLocalReferences { get; private set; } = false;
-        public bool EnablePagination { get; private set; } = false;
-        public bool EnableDiscriminatorValue { get; private set; } = false;
-        public bool EnableDerivedTypesReferencesForRequestBody { get; private set; } = false;
-        public bool EnableDerivedTypesReferencesForResponses { get; private set; } = false;
-        public bool ShowRootPath { get; set; } = false;
-        public bool ShowLinks { get; set; } = false;
 
         public OpenApiStyleOptions(OpenApiStyle style, string openApiVersion = null, string graphVersion = null, string openApiFormat = null)
         {
@@ -72,10 +66,6 @@ namespace OpenAPIService.Common
             OpenApiVersion = OpenApiVersion ?? Constants.OpenApiConstants.OpenApiVersion_3;
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Yaml;
-            EnablePagination = true;
-            EnableDiscriminatorValue = false;
-            EnableDerivedTypesReferencesForRequestBody = false;
-            EnableDerivedTypesReferencesForResponses = false;
         }
 
         private void SetGEAutocompleteStyle()
@@ -84,8 +74,6 @@ namespace OpenAPIService.Common
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Json;
             InlineLocalReferences = true;
-            ShowRootPath = true;
-            ShowLinks = true;
         }
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -270,7 +270,8 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document
+        /// Gets an OpenAPI document version of Microsoft Graph based on CSDL document
+        /// from a dictionary cache or gets a new instance.
         /// </summary>
         /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -100,7 +100,7 @@ namespace OpenAPIService
 
             if (subset.Paths == null)
             {
-                throw new ArgumentException("No paths returned.");
+                throw new ArgumentException("No paths found for the supplied parameters.");
             }
 
             CopyReferences(subset);
@@ -120,13 +120,13 @@ namespace OpenAPIService
         public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url,
             OpenApiDocument source, bool forceRefresh = false)
         {
-            if (operationIds != null && tags != null)
-            {
-                throw new ArgumentException("Cannot filter by operationIds and tags at the same time.");
-            }
             if (url != null && (operationIds != null || tags != null))
             {
-                throw new ArgumentException("Cannot filter by url and either operationIds and tags at the same time.");
+                throw new InvalidOperationException("Cannot filter by url and either operationIds and tags at the same time.");
+            }
+            else if (operationIds != null && tags != null)
+            {
+                throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
             }
 
             Func<OpenApiOperation, bool> predicate;
@@ -186,7 +186,7 @@ namespace OpenAPIService
             }
             else
             {
-                throw new ArgumentNullException("Either operationIds, tags or url need to be specified.");
+                throw new InvalidOperationException("Either operationIds, tags or url need to be specified.");
             }
 
             return predicate;
@@ -338,7 +338,7 @@ namespace OpenAPIService
             if (subsetOpenApiDocument.Paths == null ||
                 !subsetOpenApiDocument.Paths.Any())
             {
-                throw new ArgumentException ("No paths returned.");
+                throw new ArgumentException ("No paths found for the supplied parameters.");
             }
 
             return subsetOpenApiDocument;

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -311,6 +311,7 @@ namespace OpenAPIService
                 // Clone doc before making changes
                 subsetOpenApiDocument = Clone(subsetOpenApiDocument);
 
+                // Remove AnyOf
                 var anyOfRemover = new AnyOfRemover();
                 var walker = new OpenApiWalker(anyOfRemover);
                 walker.Walk(subsetOpenApiDocument);


### PR DESCRIPTION
Fixes #295 

**Proposes**:
- Generating the OpenAPI document with uniform settings, then only applying styling on a subset of the openAPI doc. for each OpenApiStyle for each request. This would ideally fix the above issue in such that `GEAutocomplete` style, for example, will always have `Links` in the response payload and the root path defined in the OpenAPI doc., and at the same time, `PowerShell` style will have the option of removing the root path in its own subset of the doc. (for AutoREST compatibility).
- Adding and catching exceptions appropriately, with relevant messaging. This will greatly compliment the telemetry work already plumbed in and give us visibility on specific points and causes of failures.
- Adding and updating `OpenAPIService.Test` tests and mocks to validate the methods in the `OpenAPIService.cs` class.