### PR TITLE
Fix: Applies style appropriately on singleton OpenAPI document (#305)

### DIFF
--- a/GraphWebApi/Controllers/OpenApiController.cs
+++ b/GraphWebApi/Controllers/OpenApiController.cs
@@ -3,8 +3,8 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using GraphWebApi.Models;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Formatters.Xml;
 using Microsoft.Extensions.Configuration;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Services;
@@ -50,31 +50,41 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    return new BadRequestResult();
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
-                OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh, styleOptions);
+                OpenApiDocument source = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
 
                 var predicate = await OpenApiService.CreatePredicate(operationIds, tags, url, source, forceRefresh);
 
-                if (predicate == null)
-                {
-                    return new BadRequestResult();
-                }
+                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 
-                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions, predicate);
-
-                subsetOpenApiDocument = OpenApiService.ApplyStyle(styleOptions, subsetOpenApiDocument);
+                subsetOpenApiDocument = OpenApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument);
 
                 var stream = OpenApiService.SerializeOpenApiDocument(subsetOpenApiDocument, styleOptions);
-                return new FileStreamResult(stream, "application/json");
+
+                if (styleOptions.OpenApiFormat == "yaml")
+                {
+                    return new FileStreamResult(stream, "text/yaml");
+                }
+                else
+                {
+                    return new FileStreamResult(stream, "application/json");
+                }
             }
-            catch
+            catch (InvalidOperationException ex)
             {
-                return new BadRequestResult();
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
+            }
+            catch (Exception ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status500InternalServerError };
             }
         }
-
 
         [Route("openapi")]
         [HttpPost]
@@ -97,42 +107,41 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    return new BadRequestResult();
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
-                OpenApiDocument source = OpenApiService.ConvertCsdlToOpenApi(styleOptions, Request.Body);
+                OpenApiDocument source = OpenApiService.ConvertCsdlToOpenApi(Request.Body);
 
                 var predicate = await OpenApiService.CreatePredicate(operationIds, tags, url, source, forceRefresh);
 
-                if (predicate == null)
-                {
-                    return new BadRequestResult();
-                }
+                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions.GraphVersion, predicate);
 
-                var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, title, styleOptions, predicate);
-
-                subsetOpenApiDocument = OpenApiService.ApplyStyle(styleOptions, subsetOpenApiDocument);
+                subsetOpenApiDocument = OpenApiService.ApplyStyle(styleOptions.Style, subsetOpenApiDocument);
 
                 var stream = OpenApiService.SerializeOpenApiDocument(subsetOpenApiDocument, styleOptions);
+
                 if (styleOptions.OpenApiFormat == "yaml")
                 {
-                    return new FileStreamResult(stream, "application/yaml");
-                } else
+                    return new FileStreamResult(stream, "text/yaml");
+                }
+                else
                 {
                     return new FileStreamResult(stream, "application/json");
                 }
             }
-            catch(Exception ex)
+            catch (InvalidOperationException ex)
             {
-                
-                return new BadRequestObjectResult(new ProblemDetails()
-                {
-                    Detail = ex.Message
-                });
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
+            }
+            catch (Exception ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status500InternalServerError };
             }
         }
-
-
 
         [Route("openapi/operations")]
         [HttpGet]
@@ -150,18 +159,26 @@ namespace GraphWebApi.Controllers
 
                 if (graphUri == null)
                 {
-                    return new BadRequestResult();
+                    throw new InvalidOperationException($"Unsupported {nameof(graphVersion)} provided: '{graphVersion}'");
                 }
 
-                var graphOpenApi = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh, styleOptions);
+                var graphOpenApi = await OpenApiService.GetGraphOpenApiDocumentAsync(graphUri, forceRefresh);
                 WriteIndex(Request.Scheme + "://" + Request.Host.Value, styleOptions.GraphVersion, styleOptions.OpenApiVersion, styleOptions.OpenApiFormat,
                     graphOpenApi, Response.Body, styleOptions.Style);
 
                 return new EmptyResult();
             }
-            catch
+            catch (InvalidOperationException ex)
             {
-                return new BadRequestResult();
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status400BadRequest };
+            }
+            catch (ArgumentException ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status404NotFound };
+            }
+            catch (Exception ex)
+            {
+                return new JsonResult(ex.Message) { StatusCode = StatusCodes.Status500InternalServerError };
             }
         }
 

--- a/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
+++ b/OpenAPIService.Test/OpenAPIDocumentCreatorMock.cs
@@ -1,75 +1,59 @@
-﻿using Microsoft.OData.Edm.Csdl;
-using Microsoft.OpenApi.Models;
-// ------------------------------------------------------------------------------------------------------------------------------------------------------
+﻿// ------------------------------------------------------------------------------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
-using Microsoft.OpenApi.OData;
-using Microsoft.OpenApi.Readers;
-using Microsoft.OpenApi.Writers;
-using OpenAPIService.Common;
+using Microsoft.OpenApi.Models;
+using System.Collections.Concurrent;
 using System.IO;
-using System.Text;
-using System.Xml.Linq;
 
 namespace OpenAPIService.Test
 {
     /// <summary>
-    /// Defines a Mock class that simulates creating an OpenAPI document.
+    /// Defines a Mock class that creates an OpenAPI document from a CSDL file.
     /// </summary>
     public static class OpenAPIDocumentCreatorMock
     {
+        private static readonly ConcurrentDictionary<string, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<string, OpenApiDocument>();
+
+        /// <summary>
+        /// Gets an OpenAPI document version of Microsoft Graph based on CSDL document
+        /// from a dictionary cache or gets a new instance.
+        /// </summary>
+        /// <param name="graphDocPath">The file path of the Microsoft Graph metadata doc.</param>
+        /// <param name="forceRefresh">Don't read from in-memory cache.</param>
+        /// <returns>Instance of an OpenApiDocument</returns>
+        public static OpenApiDocument GetGraphOpenApiDocument(string graphDocPath, bool forceRefresh)
+        {
+            if (!forceRefresh && _OpenApiDocuments.TryGetValue(graphDocPath, out OpenApiDocument doc))
+            {
+                return doc;
+            }
+
+            OpenApiDocument source = CreateOpenApiDocument(graphDocPath);
+            _OpenApiDocuments[graphDocPath] = source;
+            return source;
+        }
+
         /// <summary>
         /// Creates an OpenAPI document from a CSDL document.
         /// </summary>
-        /// <param name="uri">The file path of the CSDL document location.</param>
+        /// <param name="graphDocPath">The file path of the CSDL document location.</param>
         /// <param name="styleOptions">Optional parameter that defines the style
         /// options to be used in formatting the OpenAPI document.</param>
-        /// <returns></returns>
-        public static OpenApiDocument CreateOpenApiDocument(string uri, OpenApiStyleOptions styleOptions = null)
+        /// <returns>Instance of an OpenApiDocument</returns>
+        private static OpenApiDocument CreateOpenApiDocument(string graphDocPath)
         {
-            if (string.IsNullOrEmpty(uri))
+            if (string.IsNullOrEmpty(graphDocPath))
             {
                 return null;
             }
 
-            using StreamReader streamReader = new StreamReader(uri);
+            using StreamReader streamReader = new StreamReader(graphDocPath);
             Stream csdl = streamReader.BaseStream;
 
-            var edmModel = CsdlReader.Parse(XElement.Load(csdl).CreateReader());
-
-            var settings = new OpenApiConvertSettings()
-            {
-                EnableKeyAsSegment = true,
-                EnableOperationId = true,
-                PrefixEntityTypeNameBeforeKey = true,
-                TagDepth = 2,
-                EnablePagination = styleOptions != null && styleOptions.EnablePagination,
-                EnableDiscriminatorValue = styleOptions != null && styleOptions.EnableDiscriminatorValue,
-                EnableDerivedTypesReferencesForRequestBody = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForRequestBody,
-                EnableDerivedTypesReferencesForResponses = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForResponses,
-                ShowRootPath = styleOptions != null && styleOptions.ShowRootPath
-            };
-            OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
-
-            document = FixReferences(document);
+            OpenApiDocument document = OpenApiService.ConvertCsdlToOpenApi(csdl);
 
             return document;
-        }
-
-        /// <summary>
-        /// This method is only needed because the output of ConvertToOpenApi isn't quite a valid OpenApiDocument instance.
-        /// So we write it out, and read it back in again to fix it up
-        /// </summary>
-        /// <param name="document">The OpenAPI document to be actioned.</param>
-        /// <returns></returns>
-        private static OpenApiDocument FixReferences(OpenApiDocument document)
-        {
-            var sb = new StringBuilder();
-            document.SerializeAsV3(new OpenApiYamlWriter(new StringWriter(sb)));
-            var doc = new OpenApiStringReader().Read(sb.ToString(), out _);
-
-            return doc;
         }
     }
 }

--- a/OpenAPIService.Test/OpenAPIService.Test.csproj
+++ b/OpenAPIService.Test/OpenAPIService.Test.csproj
@@ -14,10 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="TestFiles\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\OpenAPIService\OpenAPIService.csproj" />
   </ItemGroup>
 

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -3,7 +3,7 @@
 // ------------------------------------------------------------------------------------------------------------------------------------------------------
 
 using Microsoft.OpenApi.Models;
-using OpenAPIService.Common;
+using System;
 using Xunit;
 
 namespace OpenAPIService.Test
@@ -12,12 +12,30 @@ namespace OpenAPIService.Test
     {
         private const string GraphBetaCsdl = ".\\TestFiles\\Graph.Beta.OData.xml";
         private const string Title = "Partial Graph API";
-        private readonly OpenApiDocument _source = null;
+        private const string GraphVersion = "beta";
+        private readonly OpenApiDocument _graphBetaSource = null;
 
         public OpenAPIServiceShould()
         {
             // Create OpenAPI document with default OpenApiStyle = Plain
-            _source = OpenAPIDocumentCreatorMock.CreateOpenApiDocument(GraphBetaCsdl);
+            _graphBetaSource = OpenAPIDocumentCreatorMock.GetGraphOpenApiDocument(GraphBetaCsdl, false);
+        }
+
+        [Fact]
+        public void ReturnAllPathsInConvertCsdlToOpenApi()
+        {
+            // Arrange
+            var rootPath = "/";
+            var pathsCount = 4586;
+            var linksCount = _graphBetaSource.Paths[rootPath]
+                                .Operations[OperationType.Get]
+                                .Responses["200"]
+                                .Links.Count;
+
+            // Assert
+            Assert.Equal(pathsCount, _graphBetaSource.Paths.Count);
+            Assert.NotNull(_graphBetaSource.Paths["/"]);
+            Assert.Equal(62, linksCount);
         }
 
         [Fact]
@@ -26,15 +44,17 @@ namespace OpenAPIService.Test
             // Arrange
             string operationId_1 = "reports.getTeamsUserActivityCounts";
             string operationId_2 = "reports.getTeamsUserActivityUserDetail-a3f1";
-            string graphVersion = "beta";
-            OpenApiDocument source = _source;
-            OpenApiStyleOptions styleOptions = new OpenApiStyleOptions(OpenApiStyle.PowerShell, graphVersion: graphVersion);
-            var predicate_1 = OpenApiService.CreatePredicate(operationId_1, null, null, source, false).GetAwaiter().GetResult();
-            var predicate_2 = OpenApiService.CreatePredicate(operationId_2, null, null, source, false).GetAwaiter().GetResult();
+            OpenApiDocument source = _graphBetaSource;
+
+            var predicate_1 = OpenApiService.CreatePredicate(operationIds: operationId_1, tags: null, url: null, source: source)
+                .GetAwaiter().GetResult();
+
+            var predicate_2 = OpenApiService.CreatePredicate(operationIds: operationId_2, tags: null, url: null, source: source)
+                .GetAwaiter().GetResult();
 
             // Act
-            var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, styleOptions, predicate_1);
-            var subsetOpenApiDocument_2 = OpenApiService.CreateFilteredDocument(source, Title, styleOptions, predicate_2);
+            var subsetOpenApiDocument_1 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_1);
+            var subsetOpenApiDocument_2 = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate_2);
 
             // Assert
             Assert.Collection(subsetOpenApiDocument_1.Paths,
@@ -47,6 +67,213 @@ namespace OpenAPIService.Test
                {
                    Assert.Equal("/reports/microsoft.graph.getTeamsUserActivityUserDetail(date={date})", item.Key);
                });
+        }
+
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("users.user.ListUser", "users.user", "/users")]
+        [InlineData("users.user.ListUser", "users.user", null)]
+        [InlineData("users.user.ListUser", null, "/users")]
+        [InlineData(null, "users.user", "/users")]
+        public void ThrowsInvalidOperationExceptionInCreatePredicateWhenInvalidNumberOfArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act and Assert
+            if (string.IsNullOrEmpty(operationIds) &&
+                string.IsNullOrEmpty(tags) &&
+                string.IsNullOrEmpty(url))
+            {
+                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult()).Message;
+                Assert.Equal("Either operationIds, tags or url need to be specified.", message);
+            }
+            else
+            {
+                var message = Assert.Throws<InvalidOperationException>(() => OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult()).Message;
+
+                if (url != null && (operationIds != null || tags != null))
+                {
+                    Assert.Equal("Cannot filter by url and either operationIds and tags at the same time.", message);
+                }
+                else if (operationIds != null && tags != null)
+                {
+                    Assert.Equal("Cannot filter by operationIds and tags at the same time.", message);
+                }
+            }
+        }
+
+        [Fact]
+        public void ThrowsArgumentExceptionInCreatePredicateWhenNonExistentUrlArgumentIsSpecified()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act and Assert
+            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/foo", source: source)
+                                .GetAwaiter().GetResult()).Message;
+            Assert.Equal("The url supplied could not be found.", message);
+        }
+
+        [Fact]
+        public void ThrowsArgumentExceptionInApplyStyleWhenNoPathsAreReturned()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: "/", source: source)
+                                .GetAwaiter().GetResult(); // root path will be non-existent in a PowerShell styled doc.
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            // Act & Assert
+            var message = Assert.Throws<ArgumentException>(() => OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument)).Message;
+            Assert.Equal("No paths found for the supplied parameters.", message);
+        }
+
+        [Theory]
+        [InlineData("foo.bar", null)]
+        [InlineData(null, "bar.foo")]
+        public void ThrowsArgumentExceptionInCreateFilteredDocumentWhenNonExistentOperationIdsAndTagsAreSupplied(string operationIds, string tags)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: null, source: source)
+                                .GetAwaiter().GetResult();
+
+            // Act & Assert
+            var message = Assert.Throws<ArgumentException>(() => OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate)).Message;
+            Assert.Equal("No paths found for the supplied parameters.", message);
+        }
+
+        [Theory]
+        [InlineData(null, null, "/users")]
+        [InlineData(null, "users.user", null)]
+        [InlineData("users.user.ListUser", null, null)]
+        public void ReturnValueInCreatePredicateWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            // Assert
+            Assert.NotNull(predicate);
+        }
+
+        [Theory]
+        [InlineData(null, null, "/users")]
+        [InlineData(null, "users.user", null)]
+        [InlineData("users.user.ListUser", null, null)]
+        public void ReturnOpenApiDocumentInCreateFilteredDocumentWhenValidArgumentsAreSpecified(string operationIds, string tags, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: operationIds, tags: tags, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            // Assert
+            Assert.NotNull(subsetOpenApiDocument);
+
+            if (!string.IsNullOrEmpty(operationIds))
+            {
+                Assert.Single(subsetOpenApiDocument.Paths);
+            }
+            else if (!string.IsNullOrEmpty(tags))
+            {
+                Assert.Equal(2, subsetOpenApiDocument.Paths.Count);
+            }
+            else // url
+            {
+                Assert.Single(subsetOpenApiDocument.Paths);
+            }
+        }
+
+        [Theory]
+        [InlineData(OpenApiStyle.Plain, "/users/{user-id}")]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}")]
+        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
+        [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
+        public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url)
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: null, tags: null, url: url, source: source)
+                                .GetAwaiter().GetResult();
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(style, subsetOpenApiDocument);
+
+            // Assert
+            if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
+            {
+                var content = subsetOpenApiDocument.Paths[url]
+                                .Operations[OperationType.Get]
+                                .Responses["200"]
+                                .Content;
+
+                Assert.Single(subsetOpenApiDocument.Paths);
+
+                if (style == OpenApiStyle.GEAutocomplete)
+                {
+                    Assert.Empty(content);
+                }
+                else // Plain
+                {
+                    Assert.NotEmpty(content);
+                }
+            }
+            else // PowerShell || PowerPlatform
+            {
+                var anyOf = subsetOpenApiDocument.Paths[url]
+                                .Operations[OperationType.Post]
+                                .Responses["200"]
+                                .Content["application/json"]
+                                .Schema
+                                .AnyOf;
+
+                Assert.Null(anyOf);
+
+                if (style == OpenApiStyle.PowerShell)
+                {
+                    var newOperationId = subsetOpenApiDocument.Paths[url]
+                                            .Operations[OperationType.Post]
+                                            .OperationId;
+
+                    Assert.Equal("administrativeUnits_restore", newOperationId);
+                }
+            }
+        }
+
+        [Fact]
+        public void RemoveRootPathFromOpenApiDocumentInApplyStyleForPowerShellOpenApiStyle()
+        {
+            // Arrange
+            OpenApiDocument source = _graphBetaSource;
+
+            // Act
+            var predicate = OpenApiService.CreatePredicate(operationIds: "*", tags: null, url: null, source: source)
+                                .GetAwaiter().GetResult(); // fetch all paths/operations
+
+            var subsetOpenApiDocument = OpenApiService.CreateFilteredDocument(source, Title, GraphVersion, predicate);
+
+            subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
+
+            // Assert
+            Assert.Equal(4585, subsetOpenApiDocument.Paths.Count);
+            Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
         }
     }
 }

--- a/OpenAPIService/Common/OpenApiStyleOptions.cs
+++ b/OpenAPIService/Common/OpenApiStyleOptions.cs
@@ -14,12 +14,6 @@ namespace OpenAPIService.Common
         public string GraphVersion { get; private set; }
         public string OpenApiFormat { get; private set; }
         public bool InlineLocalReferences { get; private set; } = false;
-        public bool EnablePagination { get; private set; } = false;
-        public bool EnableDiscriminatorValue { get; private set; } = false;
-        public bool EnableDerivedTypesReferencesForRequestBody { get; private set; } = false;
-        public bool EnableDerivedTypesReferencesForResponses { get; private set; } = false;
-        public bool ShowRootPath { get; set; } = false;
-        public bool ShowLinks { get; set; } = false;
 
         public OpenApiStyleOptions(OpenApiStyle style, string openApiVersion = null, string graphVersion = null, string openApiFormat = null)
         {
@@ -72,10 +66,6 @@ namespace OpenAPIService.Common
             OpenApiVersion = OpenApiVersion ?? Constants.OpenApiConstants.OpenApiVersion_3;
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Yaml;
-            EnablePagination = true;
-            EnableDiscriminatorValue = false;
-            EnableDerivedTypesReferencesForRequestBody = false;
-            EnableDerivedTypesReferencesForResponses = false;
         }
 
         private void SetGEAutocompleteStyle()
@@ -84,8 +74,6 @@ namespace OpenAPIService.Common
             GraphVersion = GraphVersion ?? Constants.OpenApiConstants.GraphVersion_V1;
             OpenApiFormat = OpenApiFormat ?? Constants.OpenApiConstants.Format_Json;
             InlineLocalReferences = true;
-            ShowRootPath = true;
-            ShowLinks = true;
         }
     }
 }

--- a/OpenAPIService/OpenApiService.cs
+++ b/OpenAPIService/OpenApiService.cs
@@ -34,15 +34,14 @@ namespace OpenAPIService
 
     public class OpenApiService
     {
-        private static ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<Uri, OpenApiDocument>();
-        private static OpenApiDocument _source = new OpenApiDocument();
+        private static readonly ConcurrentDictionary<Uri, OpenApiDocument> _OpenApiDocuments = new ConcurrentDictionary<Uri, OpenApiDocument>();
         private static UriTemplateTable _uriTemplateTable = new UriTemplateTable();
         private static IDictionary<int, OpenApiOperation[]> _openApiOperationsTable = new Dictionary<int, OpenApiOperation[]>();
 
         /// <summary>
         /// Create partial document based on provided predicate
         /// </summary>
-        public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, OpenApiStyleOptions styleOptions, Func<OpenApiOperation, bool> predicate)
+        public static OpenApiDocument CreateFilteredDocument(OpenApiDocument source, string title, string graphVersion, Func<OpenApiOperation, bool> predicate)
         {
 
             var subset = new OpenApiDocument
@@ -50,7 +49,7 @@ namespace OpenAPIService
                 Info = new OpenApiInfo()
                 {
                     Title = title,
-                    Version = styleOptions.GraphVersion
+                    Version = graphVersion
                 },
 
                 Components = new OpenApiComponents()
@@ -73,7 +72,7 @@ namespace OpenAPIService
 
             subset.SecurityRequirements.Add(new OpenApiSecurityRequirement() { { aadv2Scheme, new string[] { } } });
 
-            subset.Servers.Add(new OpenApiServer() { Description = "Core", Url = string.Format(Constants.GraphConstants.GraphUrl, styleOptions.GraphVersion) });
+            subset.Servers.Add(new OpenApiServer() { Description = "Core", Url = string.Format(Constants.GraphConstants.GraphUrl, graphVersion) });
 
             var results = FindOperations(source, predicate);
             foreach (var result in results)
@@ -101,13 +100,7 @@ namespace OpenAPIService
 
             if (subset.Paths == null)
             {
-                throw new ArgumentNullException("No paths returned.");
-            }
-
-            if (styleOptions.Style == OpenApiStyle.GEAutocomplete)
-            {
-                // Content property and its schema $refs are unnecessary for autocomplete
-                RemoveContent(subset);
+                throw new ArgumentException("No paths found for the supplied parameters.");
             }
 
             CopyReferences(subset);
@@ -125,15 +118,15 @@ namespace OpenAPIService
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>
         /// <returns>A predicate</returns>
         public static async Task<Func<OpenApiOperation, bool>> CreatePredicate(string operationIds, string tags, string url,
-            OpenApiDocument source, bool forceRefresh)
-         {
-            if (operationIds != null && tags != null)
-            {
-                return null; // Cannot filter by operationIds and tags at the same time
-            }
+            OpenApiDocument source, bool forceRefresh = false)
+        {
             if (url != null && (operationIds != null || tags != null))
             {
-                return null; // Cannot filter by url and either 0perationIds and tags at the same time
+                throw new InvalidOperationException("Cannot filter by url and either operationIds and tags at the same time.");
+            }
+            else if (operationIds != null && tags != null)
+            {
+                throw new InvalidOperationException("Cannot filter by operationIds and tags at the same time.");
             }
 
             Func<OpenApiOperation, bool> predicate;
@@ -181,7 +174,7 @@ namespace OpenAPIService
 
                 if (resultMatch == null)
                 {
-                    return null;
+                    throw new ArgumentException("The url supplied could not be found.");
                 }
 
                 /* Fetch the corresponding Operations Id(s) for the matched url */
@@ -193,7 +186,7 @@ namespace OpenAPIService
             }
             else
             {
-                predicate = null;
+                throw new InvalidOperationException("Either operationIds, tags or url need to be specified.");
             }
 
             return predicate;
@@ -203,8 +196,8 @@ namespace OpenAPIService
         /// Populates the _uriTemplateTable with the Graph url paths and the _openApiOperationsTable
         /// with the respective OpenApiOperations for these urls paths.
         /// </summary>
-        /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
-        /// <param name="forceRefresh">Don't read from in-memory cache.</param>
+        /// <param name="source">The OpenAPI document.</param>
+        /// <returns>A task.</returns>
         private static async Task PopulateReferenceTablesAync(OpenApiDocument source)
         {
             HashSet<string> uniqueUrlsTable = new HashSet<string>(); // to ensure unique url path entries in the UriTemplate table
@@ -230,8 +223,8 @@ namespace OpenAPIService
         /// Create a representation of the OpenApiDocument to return from an API
         /// </summary>
         /// <param name="subset">OpenAPI document.</param>
-        /// <param name="OpenApiStyleOptions">The modal object containing the required styling options.</param>
-        /// <returns></returns>
+        /// <param name="styleOptions">The modal object containing the required styling options.</param>
+        /// <returns>A memory stream.</returns>
         public static MemoryStream SerializeOpenApiDocument(OpenApiDocument subset, OpenApiStyleOptions styleOptions)
         {
             var stream = new MemoryStream();
@@ -277,13 +270,13 @@ namespace OpenAPIService
         }
 
         /// <summary>
-        /// Get OpenApiDocument version of Microsoft Graph based on CSDL document
+        /// Gets an OpenAPI document version of Microsoft Graph based on CSDL document
+        /// from a dictionary cache or gets a new instance.
         /// </summary>
         /// <param name="graphUri">The uri of the Microsoft Graph metadata doc.</param>
         /// <param name="forceRefresh">Don't read from in-memory cache.</param>
-        /// <param name="styleOptions">Optional modal object containing the required styling options.</param>
-        /// <returns>Instance of an OpenApiDocument</returns>
-        public static async Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh, OpenApiStyleOptions styleOptions = null)
+        /// <returns>A task of the value of an OpenAPI document.</returns>
+        public static async Task<OpenApiDocument> GetGraphOpenApiDocumentAsync(string graphUri, bool forceRefresh)
         {
             var csdlHref = new Uri(graphUri);
             if (!forceRefresh && _OpenApiDocuments.TryGetValue(csdlHref, out OpenApiDocument doc))
@@ -291,7 +284,7 @@ namespace OpenAPIService
                 return doc;
             }
 
-            OpenApiDocument source = await CreateOpenApiDocumentAsync(csdlHref, styleOptions);
+            OpenApiDocument source = await CreateOpenApiDocumentAsync(csdlHref);
             _OpenApiDocuments[csdlHref] = source;
             return source;
         }
@@ -299,37 +292,53 @@ namespace OpenAPIService
         /// <summary>
         /// Update the OpenAPI document based on the style option
         /// </summary>
-        /// <param name="style"></param>
-        /// <param name="subsetOpenApiDocument"></param>
-        /// <returns></returns>
-        public static OpenApiDocument ApplyStyle(OpenApiStyleOptions styleOptions, OpenApiDocument subsetOpenApiDocument)
+        /// <param name="style">The OpenApiStyle value.</param>
+        /// <param name="subsetOpenApiDocument">The subset of an OpenAPI document.</param>
+        /// <returns>An OpenAPI doc with the respective style applied.</returns>
+        public static OpenApiDocument ApplyStyle(OpenApiStyle style, OpenApiDocument subsetOpenApiDocument)
         {
-            if (styleOptions.Style == OpenApiStyle.Plain)
+            if (style == OpenApiStyle.GEAutocomplete)
             {
-                return subsetOpenApiDocument;
+                // Clone doc before making changes
+                subsetOpenApiDocument = Clone(subsetOpenApiDocument);
+
+                // The Content property and its schema $refs are unnecessary for autocomplete
+                RemoveContent(subsetOpenApiDocument);
             }
-
-            /* For Powershell and PowerPlatform Styles */
-
-            // Clone doc before making changes
-            subsetOpenApiDocument = Clone(subsetOpenApiDocument);
-
-            var anyOfRemover = new AnyOfRemover();
-            var walker = new OpenApiWalker(anyOfRemover);
-            walker.Walk(subsetOpenApiDocument);
-
-            if (styleOptions.Style == OpenApiStyle.PowerShell)
+            else if (style == OpenApiStyle.PowerShell || style == OpenApiStyle.PowerPlatform)
             {
-                // Format the OperationId for Powershell cmdlet names generation
-                var powershellFormatter = new PowershellFormatter();
-                walker = new OpenApiWalker(powershellFormatter);
+                /* For Powershell and PowerPlatform Styles */
+
+                // Clone doc before making changes
+                subsetOpenApiDocument = Clone(subsetOpenApiDocument);
+
+                // Remove AnyOf
+                var anyOfRemover = new AnyOfRemover();
+                var walker = new OpenApiWalker(anyOfRemover);
                 walker.Walk(subsetOpenApiDocument);
 
-                var version = subsetOpenApiDocument.Info.Version;
-                if (!new Regex("v\\d\\.\\d").Match(version).Success)
+                if (style == OpenApiStyle.PowerShell)
                 {
-                    subsetOpenApiDocument.Info.Version = "v1.0-" + version;
+                    // Format the OperationId for Powershell cmdlet names generation
+                    var powershellFormatter = new PowershellFormatter();
+                    walker = new OpenApiWalker(powershellFormatter);
+                    walker.Walk(subsetOpenApiDocument);
+
+                    var version = subsetOpenApiDocument.Info.Version;
+                    if (!new Regex("v\\d\\.\\d").Match(version).Success)
+                    {
+                        subsetOpenApiDocument.Info.Version = "v1.0-" + version;
+                    }
+
+                    // Remove the root path to make AutoREST happy
+                    subsetOpenApiDocument.Paths.Remove("/");
                 }
+            }
+
+            if (subsetOpenApiDocument.Paths == null ||
+                !subsetOpenApiDocument.Paths.Any())
+            {
+                throw new ArgumentException ("No paths found for the supplied parameters.");
             }
 
             return subsetOpenApiDocument;
@@ -343,21 +352,26 @@ namespace OpenAPIService
             writer.Flush();
             stream.Position = 0;
             var reader = new OpenApiStreamReader();
-            return reader.Read(stream, out OpenApiDiagnostic diag);
+            return reader.Read(stream, out _);
         }
 
-        private static async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref, OpenApiStyleOptions styleOptions = null)
+        private static async Task<OpenApiDocument> CreateOpenApiDocumentAsync(Uri csdlHref)
         {
             var httpClient = CreateHttpClient();
 
             Stream csdl = await httpClient.GetStreamAsync(csdlHref.OriginalString);
 
-            OpenApiDocument document = ConvertCsdlToOpenApi(styleOptions, csdl);
+            OpenApiDocument document = ConvertCsdlToOpenApi(csdl);
 
             return document;
         }
 
-        public static OpenApiDocument ConvertCsdlToOpenApi(OpenApiStyleOptions styleOptions, Stream csdl)
+        /// <summary>
+        /// Converts CSDL to OpenAPI
+        /// </summary>
+        /// <param name="csdl">The CSDL stream.</param>
+        /// <returns>An OpenAPI document.</returns>
+        public static OpenApiDocument ConvertCsdlToOpenApi(Stream csdl)
         {
             var edmModel = CsdlReader.Parse(XElement.Load(csdl).CreateReader());
 
@@ -367,12 +381,12 @@ namespace OpenAPIService
                 EnableOperationId = true,
                 PrefixEntityTypeNameBeforeKey = true,
                 TagDepth = 2,
-                EnablePagination = styleOptions != null && styleOptions.EnablePagination,
-                EnableDiscriminatorValue = styleOptions != null && styleOptions.EnableDiscriminatorValue,
-                EnableDerivedTypesReferencesForRequestBody = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForRequestBody,
-                EnableDerivedTypesReferencesForResponses = styleOptions != null && styleOptions.EnableDerivedTypesReferencesForResponses,
-                ShowRootPath = styleOptions != null && styleOptions.ShowRootPath,
-                ShowLinks = styleOptions != null && styleOptions.ShowLinks
+                EnablePagination = true,
+                EnableDiscriminatorValue = false,
+                EnableDerivedTypesReferencesForRequestBody = false,
+                EnableDerivedTypesReferencesForResponses = false,
+                ShowRootPath = true,
+                ShowLinks = true
             };
             OpenApiDocument document = edmModel.ConvertToOpenApi(settings);
 


### PR DESCRIPTION
* Add exception throwing; refactor styleOptions; remove root path for PowerShell

* Refactor out unnecessary styleOptions properties

* Add and update tests to validate OpenApiService methods

* Update controller to handle exceptions appropriately

* Nit: add comment; update test method names

* Update xml summary documentation

* Refactor out code to use the implementation in OpenAPIService

* Add more test points; code formatting

* Add InvalidOperationExceptions to distinguish from ArgumentExceptions

* Add/update tests

Co-authored-by: Irvine Sunday <irochand@microsoft.com>