### PR TITLE
Updates PowerShell style to use Set in place of Update for PATCH Operations

### DIFF
--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -26,7 +26,7 @@ namespace OpenAPIService.Test
         {
             // Arrange
             var rootPath = "/";
-            var pathsCount = 4586;
+            var pathsCount = 4458;
             var linksCount = _graphBetaSource.Paths[rootPath]
                                 .Operations[OperationType.Get]
                                 .Responses["200"]
@@ -199,11 +199,12 @@ namespace OpenAPIService.Test
         }
 
         [Theory]
-        [InlineData(OpenApiStyle.Plain, "/users/{user-id}")]
-        [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}")]
-        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
-        [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore")]
-        public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url)
+        [InlineData(OpenApiStyle.Plain, "/users/{user-id}", OperationType.Get)]
+        [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}", OperationType.Get)]
+        [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
+        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
+        [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch)]
+        public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url, OperationType operationType)
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;
@@ -220,7 +221,7 @@ namespace OpenAPIService.Test
             if (style == OpenApiStyle.GEAutocomplete || style == OpenApiStyle.Plain)
             {
                 var content = subsetOpenApiDocument.Paths[url]
-                                .Operations[OperationType.Get]
+                                .Operations[operationType]
                                 .Responses["200"]
                                 .Content;
 
@@ -237,22 +238,36 @@ namespace OpenAPIService.Test
             }
             else // PowerShell || PowerPlatform
             {
-                var anyOf = subsetOpenApiDocument.Paths[url]
-                                .Operations[OperationType.Post]
-                                .Responses["200"]
-                                .Content["application/json"]
-                                .Schema
-                                .AnyOf;
+                if (operationType == OperationType.Post)
+                {
+                    var anyOf = subsetOpenApiDocument.Paths[url]
+                                    .Operations[operationType]
+                                    .Responses["200"]
+                                    .Content["application/json"]
+                                    .Schema
+                                    .AnyOf;
 
-                Assert.Null(anyOf);
+                    Assert.Null(anyOf);
+                }
 
                 if (style == OpenApiStyle.PowerShell)
                 {
-                    var newOperationId = subsetOpenApiDocument.Paths[url]
-                                            .Operations[OperationType.Post]
+                    if (operationType == OperationType.Post)
+                    {
+                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                                            .Operations[operationType]
                                             .OperationId;
 
-                    Assert.Equal("administrativeUnits_restore", newOperationId);
+                        Assert.Equal("administrativeUnits_restore", newOperationId);
+                    }
+                    else if (operationType == OperationType.Patch)
+                    {
+                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                                            .Operations[operationType]
+                                            .OperationId;
+
+                        Assert.Equal("users.user_SetUser", newOperationId);
+                    }
                 }
             }
         }
@@ -272,7 +287,7 @@ namespace OpenAPIService.Test
             subsetOpenApiDocument = OpenApiService.ApplyStyle(OpenApiStyle.PowerShell, subsetOpenApiDocument);
 
             // Assert
-            Assert.Equal(4585, subsetOpenApiDocument.Paths.Count);
+            Assert.Equal(4457, subsetOpenApiDocument.Paths.Count);
             Assert.False(subsetOpenApiDocument.Paths.ContainsKey("/")); // root path
         }
     }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -269,6 +269,14 @@ namespace OpenAPIService.Test
 
                         Assert.Equal("users.user_UpdateUser", newOperationId);
                     }
+                    else if (operationType == OperationType.Put)
+                    {
+                        var newOperationId = subsetOpenApiDocument.Paths[url]
+                                            .Operations[operationType]
+                                            .OperationId;
+
+                        Assert.Equal("applications.application_SetLogo", newOperationId);
+                    }
                 }
             }
         }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -204,6 +204,7 @@ namespace OpenAPIService.Test
         [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
         [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
         [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch)]
+        [InlineData(OpenApiStyle.PowerShell, "/applications/{application-id}/logo", OperationType.Put)]
         public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url, OperationType operationType)
         {
             // Arrange

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -267,7 +267,7 @@ namespace OpenAPIService.Test
                                             .Operations[operationType]
                                             .OperationId;
 
-                        Assert.Equal("users.user_SetUser", newOperationId);
+                        Assert.Equal("users.user_UpdateUser", newOperationId);
                     }
                 }
             }

--- a/OpenAPIService.Test/OpenAPIServiceShould.cs
+++ b/OpenAPIService.Test/OpenAPIServiceShould.cs
@@ -202,10 +202,11 @@ namespace OpenAPIService.Test
         [InlineData(OpenApiStyle.Plain, "/users/{user-id}", OperationType.Get)]
         [InlineData(OpenApiStyle.GEAutocomplete, "/users/{user-id}", OperationType.Get)]
         [InlineData(OpenApiStyle.PowerPlatform, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
-        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post)]
-        [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch)]
-        [InlineData(OpenApiStyle.PowerShell, "/applications/{application-id}/logo", OperationType.Put)]
-        public void ReturnOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url, OperationType operationType)
+        [InlineData(OpenApiStyle.PowerShell, "/administrativeUnits/{administrativeUnit-id}/microsoft.graph.restore", OperationType.Post, "administrativeUnits_restore")]
+        [InlineData(OpenApiStyle.PowerShell, "/users/{user-id}", OperationType.Patch, "users.user_UpdateUser")]
+        [InlineData(OpenApiStyle.PowerShell, "/applications/{application-id}/logo", OperationType.Put, "applications.application_SetLogo")]
+        public void ReturnStyledOpenApiDocumentInApplyStyleForAllOpenApiStyles(OpenApiStyle style, string url,
+            OperationType operationType, string expectedOperationId = null)
         {
             // Arrange
             OpenApiDocument source = _graphBetaSource;
@@ -259,7 +260,7 @@ namespace OpenAPIService.Test
                                             .Operations[operationType]
                                             .OperationId;
 
-                        Assert.Equal("administrativeUnits_restore", newOperationId);
+                        Assert.Equal(expectedOperationId, newOperationId);
                     }
                     else if (operationType == OperationType.Patch)
                     {
@@ -267,7 +268,7 @@ namespace OpenAPIService.Test
                                             .Operations[operationType]
                                             .OperationId;
 
-                        Assert.Equal("users.user_UpdateUser", newOperationId);
+                        Assert.Equal(expectedOperationId, newOperationId);
                     }
                     else if (operationType == OperationType.Put)
                     {
@@ -275,7 +276,7 @@ namespace OpenAPIService.Test
                                             .Operations[operationType]
                                             .OperationId;
 
-                        Assert.Equal("applications.application_SetLogo", newOperationId);
+                        Assert.Equal(expectedOperationId, newOperationId);
                     }
                 }
             }

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -13,8 +13,31 @@ namespace OpenAPIService
    /// </summary>
     internal class PowershellFormatter : OpenApiVisitorBase
     {
-        private const string DefaultPatchPrefix = ".Update";
-        private const string NewPatchPrefix = "_Set";
+        private const string DefaultPutPrefix = ".Update";
+        private const string NewPutPrefix = "_Set";
+
+        /// <summary>
+        /// Accesses the individual OpenAPI operations for a particular OpenApiPathItem.
+        /// </summary>
+        /// <param name="pathItem">The OpenApiPathItem.</param>
+        public override void Visit(OpenApiPathItem pathItem)
+        {
+            var putOperation = OperationType.Put;
+
+            // For PowerShell, Put operation id should have the format -> {xxx}_Set{Yyy}
+            if (pathItem.Operations.ContainsKey(putOperation))
+            {
+                var operationId = pathItem.Operations[putOperation].OperationId;
+
+                if (operationId.Contains(DefaultPutPrefix))
+                {
+                    StringBuilder newOperationId = new StringBuilder(operationId);
+
+                    newOperationId.Replace(DefaultPutPrefix, NewPutPrefix);
+                    pathItem.Operations[putOperation].OperationId = newOperationId.ToString();
+                }
+            }
+        }
 
         /// <summary>
         /// The last '.' character of the OperationId value separates the method group from the operation name.
@@ -25,27 +48,21 @@ namespace OpenAPIService
             var operationId = operation.OperationId;
 
             int charPos = operationId.LastIndexOf('.', operationId.Length - 1);
-            if (charPos >= 0)
+
+            // Check whether Put operation id already got updated
+            if (charPos >= 0 && !operationId.Contains(NewPutPrefix))
             {
                 StringBuilder newOperationId = new StringBuilder(operationId);
 
-                // Patch operation id should have the format -> {xxx}_Set{Yyy}
-                if (operationId.Contains(DefaultPatchPrefix))
-                {
-                    newOperationId.Replace(DefaultPatchPrefix, NewPatchPrefix);
-                }
-                else
-                {
-                    newOperationId[charPos] = '_';
-                }
-
+                newOperationId[charPos] = '_';
                 operation.OperationId = newOperationId.ToString();
             }
         }
 
         public override void Visit(OpenApiSchema schema)
         {
-            if (schema?.Type == "object") {
+            if (schema?.Type == "object")
+            {
                 schema.AdditionalProperties = new OpenApiSchema() {Type = "object"};  // To make AutoREST happy
             }
             base.Visit(schema);

--- a/OpenAPIService/PowershellFormatter.cs
+++ b/OpenAPIService/PowershellFormatter.cs
@@ -13,6 +13,8 @@ namespace OpenAPIService
    /// </summary>
     internal class PowershellFormatter : OpenApiVisitorBase
     {
+        private const string DefaultPatchPrefix = ".Update";
+        private const string NewPatchPrefix = "_Set";
 
         /// <summary>
         /// The last '.' character of the OperationId value separates the method group from the operation name.
@@ -27,7 +29,16 @@ namespace OpenAPIService
             {
                 StringBuilder newOperationId = new StringBuilder(operationId);
 
-                newOperationId[charPos] = '_';
+                // Patch operation id should have the format -> {xxx}_Set{Yyy}
+                if (operationId.Contains(DefaultPatchPrefix))
+                {
+                    newOperationId.Replace(DefaultPatchPrefix, NewPatchPrefix);
+                }
+                else
+                {
+                    newOperationId[charPos] = '_';
+                }
+
                 operation.OperationId = newOperationId.ToString();
             }
         }


### PR DESCRIPTION
Closes #315 

Proposes:
- Updating the PowerShell style formatter to update operation ids of the format _{xxx}.Update{Yyy}_ for `PATCH` operations to _{xxx}_Set{Yyy}_ e.g. `users.user.UpdateUser` to `users.user_SetUser`
- Adding test to validate the above feature.