### PR TITLE
Adds support for default Namespace in C#

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -891,7 +891,7 @@ namespace CodeSnippetsReflection.Test
             var result = new CSharpGenerator(betaIeEdmModel).GenerateCodeSnippet(snippetModel, expressions);
 
             //Assert code snippet string matches expectation
-            const string expectedSnippet = "var set = new TermStore.Set\r\n" +
+            const string expectedSnippet = "var set = new Microsoft.Graph.TermStore.Set\r\n" +
                                            "{\r\n" +
                                                 "\tDescription = \"mySet\"\r\n" +
                                            "};\r\n" +

--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -871,5 +871,38 @@ namespace CodeSnippetsReflection.Test
             //Assert the snippet generated is as expected
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
+
+        [Fact]
+        // This tests asserts that snippets is correctly generated for other namespaces
+        public void GeneratesSnippetsInOtherNamespace()
+        {
+            //Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+            var requestPayload = new HttpRequestMessage(HttpMethod.Patch, "https://graph.microsoft.com/beta/termStore/sets/{setId}");
+            const string jsonObject = "{\r\n" +
+                                      "  \"description\": \"mySet\",\r\n" +
+                                      "}";
+            requestPayload.Content = new StringContent(jsonObject);
+            string betaServiceUrl = "https://graph.microsoft.com/beta";
+            IEdmModel betaIeEdmModel = CsdlReader.Parse(XmlReader.Create(betaServiceUrl + "/$metadata"));
+            var snippetModel = new SnippetModel(requestPayload, betaServiceUrl, betaIeEdmModel);
+            
+            //Act by generating the code snippet
+            var result = new CSharpGenerator(betaIeEdmModel).GenerateCodeSnippet(snippetModel, expressions);
+
+            //Assert code snippet string matches expectation
+            const string expectedSnippet = "var set = new TermStore.Set\r\n" +
+                                           "{\r\n" +
+                                                "\tDescription = \"mySet\"\r\n" +
+                                           "};\r\n" +
+                                           "\r\n" +
+                                           "await graphClient.TermStore.Sets[\"{setId}\"]\n" +
+                                                "\t.Request()\n" +
+                                                "\t.UpdateAsync(set);";
+
+            //Assert the snippet generated is as expected
+            Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
+        }
+
     }
 }

--- a/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
+++ b/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
@@ -1,6 +1,7 @@
 ﻿using CodeSnippetsReflection.LanguageGenerators;
 using Microsoft.OData.Edm;
 using System.Linq;
+using System.Reflection.Metadata;
 
 namespace CodeSnippetsReflection.TypeProperties
 {
@@ -32,17 +33,17 @@ namespace CodeSnippetsReflection.TypeProperties
                     return className;
 
                 // Otherwise modify the classname by concatenation the Namespace prefix.
-                // 1. Fist remove the prefix which is the default namespace
-                // 2. Join any parts by uppercase first letter and dots.
-                var suffix = namespaceString.Replace(DefaultNamespace + ".", string.Empty);
-                var segments = suffix.Split(".");
+                // Join any parts by uppercase first letter and dots.
+                var segments = namespaceString.Split(".");
+                var fullClassName = string.Empty;
                 foreach (var segment in segments)
                 {
                     // prepend the uppercase of each segment and form the classname
                     var uppercaseSegment = CommonGenerator.UppercaseFirstLetter(segment);
-                    className = uppercaseSegment + "." + className;
+                    fullClassName = fullClassName + "." + uppercaseSegment;
                 }
-                return className;
+                // remove starting dot
+                return fullClassName.Substring(1) + "." + className;
             }
         }
 

--- a/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
+++ b/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
@@ -1,7 +1,7 @@
 ﻿using CodeSnippetsReflection.LanguageGenerators;
 using Microsoft.OData.Edm;
 using System.Linq;
-using System.Reflection.Metadata;
+using System.Text;
 
 namespace CodeSnippetsReflection.TypeProperties
 {
@@ -35,15 +35,17 @@ namespace CodeSnippetsReflection.TypeProperties
                 // Otherwise modify the classname by concatenating with the Namespace prefix.
                 // Join any parts by uppercase first letter and dots.
                 var segments = namespaceString.Split(".");
-                var fullClassName = string.Empty;
+                var stringBuilder = new StringBuilder();
                 foreach (var segment in segments)
                 {
                     // prepend the uppercase of each segment and form the classname
                     var uppercaseSegment = CommonGenerator.UppercaseFirstLetter(segment);
-                    fullClassName = fullClassName + "." + uppercaseSegment;
+                    stringBuilder.Append("." + uppercaseSegment);
                 }
+                // append the classname
+                stringBuilder.Append("." + className);
                 // remove starting dot
-                return fullClassName.Substring(1) + "." + className;
+                return stringBuilder.ToString().Substring(1);
             }
         }
 

--- a/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
+++ b/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
@@ -32,7 +32,7 @@ namespace CodeSnippetsReflection.TypeProperties
                 if (namespaceString.Equals(DefaultNamespace) || namespaceString == "Edm") 
                     return className;
 
-                // Otherwise modify the classname by concatenation the Namespace prefix.
+                // Otherwise modify the classname by concatenating with the Namespace prefix.
                 // Join any parts by uppercase first letter and dots.
                 var segments = namespaceString.Split(".");
                 var fullClassName = string.Empty;

--- a/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
+++ b/CodeSnippetsReflection/TypeProperties/CSharpTypeProperties.cs
@@ -7,6 +7,11 @@ namespace CodeSnippetsReflection.TypeProperties
     public class CSharpTypeProperties
     {
         /// <summary>
+        /// Default namespace string for the graph
+        /// </summary>
+        private const string DefaultNamespace = "microsoft.graph";
+
+        /// <summary>
         /// returns C# class name from graph type: microsoft.graph.data => Data
         /// </summary>
         public string ClassName {
@@ -19,6 +24,23 @@ namespace CodeSnippetsReflection.TypeProperties
                 else if (className.EndsWith("Request"))
                 {
                     className += "Object"; // disambiguate class names that end with Request
+                }
+
+                string namespaceString = (string)EdmType.GetType().GetProperty("Namespace")?.GetValue(EdmType, null) ?? DefaultNamespace;
+                // the classname is okay if we are in the default(or Edm) namespace.
+                if (namespaceString.Equals(DefaultNamespace) || namespaceString == "Edm") 
+                    return className;
+
+                // Otherwise modify the classname by concatenation the Namespace prefix.
+                // 1. Fist remove the prefix which is the default namespace
+                // 2. Join any parts by uppercase first letter and dots.
+                var suffix = namespaceString.Replace(DefaultNamespace + ".", string.Empty);
+                var segments = suffix.Split(".");
+                foreach (var segment in segments)
+                {
+                    // prepend the uppercase of each segment and form the classname
+                    var uppercaseSegment = CommonGenerator.UppercaseFirstLetter(segment);
+                    className = uppercaseSegment + "." + className;
                 }
                 return className;
             }


### PR DESCRIPTION
This PR add support for multiple namespaces in .NET snippets

A relevant test has been added to validate how .net snippets would look like.

Ideally the snippet [here](https://docs.microsoft.com/en-us/graph/api/termstore-set-update?view=graph-rest-beta&tabs=csharp#request) would change to look like this,

```c#
GraphServiceClient graphClient = new GraphServiceClient( authProvider );

var set = new Microsoft.Graph.TermStore.Set
{
	Description = "mySet"
};

await graphClient.TermStore.Sets["{setId}"]
	.Request()
	.UpdateAsync(set);
```

[Snippets Diff ](https://github.com/microsoftgraph/microsoft-graph-docs/commit/cc12eadd210b7b6bf6989a736c9950be3669ee63)