### PR TITLE
Raptor - Expose snippet generation logic as an executable

### DIFF
--- a/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj
+++ b/CodeSnippetsReflection.App/CodeSnippetsReflection.App.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CodeSnippetsReflection\CodeSnippetsReflection.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CodeSnippetsReflection.App/Program.cs
+++ b/CodeSnippetsReflection.App/Program.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace CodeSnippetsReflection.App
+{
+    /// <summary>
+    /// This is a thin layer that exposes snippet generation logic as an executable.
+    /// It takes two arguments:
+    /// Argument 0: Full path to a directory which holds HTTP snippets. HTTP snippets are expected to appear
+    ///             one per file where the file name ends with -httpSnippet.
+    /// Argument 1: Languages, comma separated.
+    ///             As of this writing, values are c#, javascript, objective-c, java
+    /// 
+    /// Output is generated in the same folder as the HTTP snippets. -httpSnippet part of the file name is
+    /// replaced with ---language.
+    /// </summary>
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            if (args.Length != 2)
+            {
+                Console.Error.WriteLine("Http snippets directory and languages should be specified");
+                Console.WriteLine(@"Example usage:
+  .\CodeSnippetReflection.App.exe C:\snippets c#,javascript");
+                return;
+            }
+
+            var httpSnippetsDir = args[0];
+            if (!Directory.Exists(httpSnippetsDir))
+            {
+                Console.Error.WriteLine($@"Directory {httpSnippetsDir} does not exist!");
+                return;
+            }
+
+            var languages = args[1]
+                .Split(",")
+                .Where(l => l != string.Empty) // eliminate trailing, leading or consecutive commas
+                .Distinct();
+
+            // splits language list into supported and unsupported languages
+            // where key "true" holds supported and key "false" holds unsupported languages
+            var languageGroups = languages
+                .GroupBy(l => SnippetsGenerator.SupportedLanguages.Contains(l.ToLowerInvariant()))
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var supportedLanguages = languageGroups.ContainsKey(true) ? languageGroups[true] : null;
+            var unsupportedLanguages = languageGroups.ContainsKey(false) ? languageGroups[false] : null;
+
+            if (supportedLanguages == null)
+            {
+                Console.Error.WriteLine($"None of the given languages are supported. Supported languages: {string.Join(" ", SnippetsGenerator.SupportedLanguages)}");
+                return;
+            }
+
+            if (unsupportedLanguages != null)
+            {
+                Console.WriteLine($"Skipping these languages as they are not currently supported: {string.Join(" ", unsupportedLanguages)}");
+                Console.WriteLine($"Supported languages: {string.Join(" ", SnippetsGenerator.SupportedLanguages)}");
+            }
+
+            var generator = new SnippetsGenerator();
+            var files = Directory.EnumerateFiles(httpSnippetsDir, "*-httpSnippet");
+
+            Console.WriteLine($"Running snippet generation for these languages: {string.Join(" ", supportedLanguages)}");
+
+            Parallel.ForEach(supportedLanguages, language =>
+            {
+                Parallel.ForEach(files, file =>
+                {
+                    ProcessFile(generator, language, file);
+                });
+            });
+
+            Console.WriteLine($"Processed {files.Count()} files.");
+        }
+
+        private static void ProcessFile(SnippetsGenerator generator, string language, string file)
+        {
+            // convert http request into a type that works with SnippetGenerator.ProcessPayloadRequest()
+            // we are not altering the types as it should continue serving the HTTP endpoint as well
+            using var streamContent = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(File.ReadAllText(file))));
+            streamContent.Headers.Add("Content-Type", "application/http;msgtype=request");
+
+            string snippet;
+            try
+            {
+                // This is a very fast operation, it is fine to make is synchronuous.
+                // With the parallel foreach in the main method, processing all snippets for C# in both Beta and V1 takes about 7 seconds.
+                // As of this writing, the code was processing 2650 snippets
+                using var message = streamContent.ReadAsHttpRequestMessageAsync().Result;
+                snippet = generator.ProcessPayloadRequest(message, language);
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"Exception while processing {file}.{Environment.NewLine}{e.Message}{Environment.NewLine}{e.StackTrace}");
+                return;
+            }
+
+            File.WriteAllText(file.Replace("-httpSnippet", $"---{language}"), snippet);
+        }
+    }
+}

--- a/CodeSnippetsReflection/SnippetsGenerator.cs
+++ b/CodeSnippetsReflection/SnippetsGenerator.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using CodeSnippetsReflection.LanguageGenerators;
+using System.Collections.Generic;
 
 namespace CodeSnippetsReflection
 {
@@ -12,6 +13,14 @@ namespace CodeSnippetsReflection
     /// </summary>
     public class SnippetsGenerator : ISnippetsGenerator
     {
+        public static HashSet<string> SupportedLanguages = new HashSet<string>
+        {
+            "c#",
+            "javascript",
+            "objective-c",
+            "java"
+        };
+
         private Lazy<IEdmModel> IedmModelV1 { get; set; }
         private Lazy<IEdmModel> IedmModelBeta { get; set; }
         private Uri ServiceRootV1 { get; set; }

--- a/MSGraphWebApi.sln
+++ b/MSGraphWebApi.sln
@@ -25,7 +25,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenAPIService.Test", "Open
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OpenAPI.OData.Reader", "Submodules\OpenAPI.NET.OData\src\Microsoft.OpenApi.OData.Reader\Microsoft.OpenAPI.OData.Reader.csproj", "{5E40F938-160A-4904-B256-946020B01042}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockTestUtility", "MockTestUtility\MockTestUtility.csproj", "{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MockTestUtility", "MockTestUtility\MockTestUtility.csproj", "{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeSnippetsReflection.App", "CodeSnippetsReflection.App\CodeSnippetsReflection.App.csproj", "{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +83,10 @@ Global
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA2AA6C8-63EC-401C-AE30-4E06DDDFFD11}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3BEB31A0-ABFB-46E7-985B-98C38F6AF5A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The purpose of this change is to have direct access to the snippet generation logic from ApiDoctor so that we don't have to make an HTTP call per snippet.

Snippet Generation is on .NET core 2.2 and ApiDoctor is on .NET Framework 4.5. Easiest way to expose the logic was through creating a thin layer of executable which wraps the snippet generation logic. Snippet generation logic continues to live in the Graph Explorer API repo to continue serving HTTP endpoint for Graph Explorer.

The contract is defined as follows:
- Caller is expected to dump all the HTTP snippets into a directory. File names are expected to end with `-httpSnippet`. Full path to this directory is the first command line argument.
- Second command line argument is the list of comma separated languages.

Example:
- Caller creates a directory `C:\snippets`
- Caller adds HTTP snippets:
  - `C:\snippets\snippet-name-httpSnippet`
  - `C:\snippets\snippet-name2-httpSnippet`
- Executable is called on ruby, c# and javascript like:
  - `CodeSnippetsReflection.App.exe C:\snippets ruby,c#,javascript`
- Console output will be:
  ```
  Skipping these languages as they are not currently supported: ruby
  Supported languages: c# javascript objective-c java
  Running snippet generation for these languages: c# javascript
  ...
  Generation related output
  ...
  ```
- At the end of execution `C:\snippets` will have the following files where the latter four will hold the snippets in corresponding languages:
  - `snippet-name-httpSnippet`
  - `snippet-name2-httpSnippet`
  - `snippet-name---c#`
  - `snippet-name---javascript`
  - `snippet-name2---c#`
  - `snippet-name2---javascript`

### Links
Addressing the prerequisite \# 2  from https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/raptor/pipeline.md#prerequisites-for-defining-the-pipeline-above

AB#6091

cc: @darrelmiller @pixieofhugs 