### PR TITLE
Fix test runs

### DIFF
--- a/CodeSnippetsReflection.Test/CodeSnippetsReflection.Test.csproj
+++ b/CodeSnippetsReflection.Test/CodeSnippetsReflection.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/PermissionsService.Test/PermissionsService.Test.csproj
+++ b/PermissionsService.Test/PermissionsService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SamplesService.Test/SamplesService.Test.csproj
+++ b/SamplesService.Test/SamplesService.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -44,6 +44,10 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    testAssemblyVer2: |
+      **/netcoreapp3.1/**.Test.dll
+      !**/*TestAdapter.dll
+      !**/obj/**
     diagnosticsEnabled: true
     otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 

--- a/pipelines/release.yml
+++ b/pipelines/release.yml
@@ -44,6 +44,8 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    diagnosticsEnabled: true
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
 - task: VSBuild@1
   inputs:

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -41,6 +41,9 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    diagnosticsEnabled: true
+    platform: AnyCPU
+    otherConsoleOptions: '/Framework:.NETCoreApp'
 
 - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
   displayName: 'Graph Client Tooling pipeline fail notification'

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -42,7 +42,6 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     diagnosticsEnabled: true
-    platform: AnyCPU
     otherConsoleOptions: '/Framework:.NETCoreApp'
 
 - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -41,6 +41,10 @@ steps:
   inputs:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    testAssemblyVer2: |
+      **/netcoreapp3.1/**.Test.dll
+      !**/*TestAdapter.dll
+      !**/obj/**
     diagnosticsEnabled: true
     otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 

--- a/pipelines/validatePR.yml
+++ b/pipelines/validatePR.yml
@@ -42,7 +42,7 @@ steps:
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
     diagnosticsEnabled: true
-    otherConsoleOptions: '/Framework:.NETCoreApp'
+    otherConsoleOptions: '/Framework:.NETCoreApp,Version=v3.1'
 
 - task: YodLabs.O365PostMessage.O365PostMessageBuild.O365PostMessageBuild@0
   displayName: 'Graph Client Tooling pipeline fail notification'


### PR DESCRIPTION
Closes https://github.com/microsoftgraph/microsoft-graph-explorer-api/issues/335
Azure pipelines seems to have removed the .net core 2.2 runtime from their runners and therefore mosts of our tests were being skipped.
This PR addresses that and test results can be viewed in the checks tab