### PR TITLE
Assign correct property name

### DIFF
--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -683,7 +683,8 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 properties = properties + "." + CommonGenerator.UppercaseFirstLetter(snippetModel.Segments[++segmentIndex].Identifier);
             }
 
-            //modify the responseVarible name
+            //modify the responseVariable name while registering the object created above.
+            var propertyName = snippetModel.ResponseVariableName;
             snippetModel.ResponseVariableName = desiredSegment.Identifier;
             var variableName = snippetModel.Segments.Last().Identifier;
             var parentClassName = GetCsharpClassName(desiredSegment, new List<string> { snippetModel.ResponseVariableName });
@@ -699,7 +700,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             {
                 //we are modifying the value
                 stringBuilder.Append($"var {snippetModel.ResponseVariableName} = new {parentClassName}();");//initialise the classname
-                stringBuilder.Append($"\n{snippetModel.ResponseVariableName}{properties} = {variableName};\n\n");
+                stringBuilder.Append($"\n{snippetModel.ResponseVariableName}{properties} = {propertyName};\n\n");
             }
 
             return stringBuilder.ToString();


### PR DESCRIPTION
fixes #299 

When the object to be updated was getting created, the context was lost for parameter name. So this change remembers the property name and assigns it to the correct value.

[Relevant diff](https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/29437...snippet-generation/30601?expand=1&short_path=8cd95d1#diff-8cd95d191f461e6970db6117549d66df3a06ff4ee268558dc16c73dc2a46491f) (ignore other files in the diff)