### PR TITLE
Fix reference assignment

### DIFF
--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -129,8 +129,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                             // if we are putting reference, we should send id to that object in PutAsync()
                             // and the request body should contain a JSON with @odata.id key
                             var body = JsonConvert.DeserializeObject(snippetModel.RequestBody) as JObject;
-                            var id = body["@odata.id"].ToString();
-                            objectToBePut = "\"{id}\"";
+
+                            // HTTP sample is in this format: https://graph.microsoft.com/v1.0/users/{id}
+                            // but C# SDK reconstructs the URL from {id}
+                            var id = body["@odata.id"].ToString().Split("/").Last();
+                            objectToBePut = $"\"{id}\"";
                         }
                         else
                         {

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -121,10 +121,22 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         throw new Exception($"No request Body present for PUT of entity {snippetModel.ResponseVariableName}");
 
                     var genericType = string.Empty;
+                    var objectToBePut = snippetModel.ResponseVariableName;
                     if (snippetModel.ContentType.Equals("application/json", StringComparison.OrdinalIgnoreCase))
                     {
-                        snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
-                        snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
+                        if (snippetModel.Segments.Last() is ReferenceSegment)
+                        {
+                            // if we are putting reference, we should send id to that object in PutAsync()
+                            // and the request body should contain a JSON with @odata.id key
+                            var body = JsonConvert.DeserializeObject(snippetModel.RequestBody) as JObject;
+                            var id = body["@odata.id"].ToString();
+                            objectToBePut = "\"{id}\"";
+                        }
+                        else
+                        {
+                            snippetBuilder.Append($"var {snippetModel.ResponseVariableName} = ");
+                            snippetBuilder.Append(CSharpGenerateObjectFromJson(segment, snippetModel.RequestBody, new List<string> { snippetModel.ResponseVariableName }));
+                        }
                     }
                     else
                     {
@@ -138,7 +150,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                         }
                     }
 
-                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.PutAsync{genericType}({snippetModel.ResponseVariableName});"));
+                    snippetBuilder.Append(GenerateRequestSection(snippetModel, $"{actions}\n\t.PutAsync{genericType}({objectToBePut});"));
 
                 }
                 else

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -124,7 +124,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     var objectToBePut = snippetModel.ResponseVariableName;
                     if (snippetModel.ContentType.Equals("application/json", StringComparison.OrdinalIgnoreCase))
                     {
-                        if (snippetModel.Segments.Last() is ReferenceSegment)
+                        if (snippetModel.Segments.Last() is NavigationPropertyLinkSegment)
                         {
                             // if we are putting reference, we should send id to that object in PutAsync()
                             // and the request body should contain a JSON with @odata.id key


### PR DESCRIPTION
fixes #300 

If the last segment of the URL is `NavigationPropertyLinkSegment`, in other words `/$ref`, and we are `PUT`ting the object, we should be using the id of an entity, not the entity itself (e.g. in the case of assigning a manager to a user).

[Generated diff](https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/30604...snippet-generation/30608?expand=1)