### PR TITLE
[Snippet Generation] Fix type inference when the value is null

### DIFF
--- a/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CSharpGeneratorShould.cs
@@ -100,6 +100,37 @@ namespace CodeSnippetsReflection.Test
             Assert.Equal(AuthProviderPrefix + expectedSnippet, result);
         }
 
+        [Fact]
+        // This tests asserts that we can generate snippets where value is assigned to null and the
+        // only type hint we have is the function parameter type.
+        public void TypeIsInferredFromActionParameters()
+        {
+            // Arrange
+            LanguageExpressions expressions = new CSharpExpressions();
+
+            // json string with nested objects string array
+            const string rowsJsonObject = @"{
+                                                ""index"": null,
+                                                ""values"": [
+                                                    [1, 2, 3],
+                                                    [4, 5, 6]
+                                                 ]
+                                            }";
+
+            var requestPayload = new HttpRequestMessage(HttpMethod.Post, "https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|name}/rows/add")
+            {
+                Content = new StringContent(rowsJsonObject)
+            };
+
+            var snippetModel = new SnippetModel(requestPayload, ServiceRootUrl, _edmModel);
+
+            // Act by generating the code snippet
+            var result = new CSharpGenerator(_edmModel).GenerateCodeSnippet(snippetModel, expressions);
+
+            // Assert the snippet generated is as expected
+            Assert.Contains("Int32? index = null;", result);
+        }
+
 
         [Fact]
         //This tests asserts that we can generate snippets from json objects with nested object lists(JArray) inside them.

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -118,11 +118,6 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     // follow the values in the comments with the example above
 
                                     var parameter = CommonGenerator.LowerCaseFirstLetter(key);  // "index"
-                                    var parameterType = os.Operations
-                                        .Single(o => o.Name == os.Identifier)                   // selects "add" action
-                                        .Parameters                                             // [bindparameter, index, values]
-                                        .Single(p => p.Name == parameter)                       // [index : Edm.Int32]
-                                        .Type;                                                  // Edm.Int32
 
                                     var path = new List<string> { CommonGenerator.LowerCaseFirstLetter(key) }; // { "index" }
                                     var value = CSharpGenerateObjectFromJson(segment, jsonString, path);       // null;
@@ -133,6 +128,12 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     // In these cases, we look for the type of "index" in action parameters.
                                     if (value.Trim() == "null;")
                                     {
+                                        var parameterType = os.Operations
+                                            .Single(o => o.Name == os.Identifier)                   // selects "add" action
+                                            .Parameters                                             // [bindparameter, index, values]
+                                            .Single(p => p.Name == parameter)                       // [index : Edm.Int32]
+                                            .Type;                                                  // Edm.Int32
+
                                         if (parameterType.IsNullable)
                                         {
                                             typeHintOnTheLeftHandSide = new CSharpTypeProperties(parameterType.Definition, false).ClassName; // Int32

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -21,6 +21,14 @@ namespace CodeSnippetsReflection.LanguageGenerators
         private readonly CommonGenerator CommonGenerator;
 
         /// <summary>
+        /// Represents the types that need a trailing ? to make it nullable.
+        /// The other Edm types have the corresponding types that are nullable by default:
+        ///     such as String and Stream (System namespace)
+        ///     or Duration, Date, TimeOfDay (Microsoft.Graph namespace)
+        /// </summary>
+        private static readonly HashSet<string> EdmTypesNonNullableByDefault = new HashSet<string>{ "Int32", "Single", "Double", "Boolean", "Guid", "DateTimeOffset", "Byte" };
+
+        /// <summary>
         /// CSharpGenerator constructor
         /// </summary>
         /// <param name="model">Model representing metadata</param>
@@ -127,7 +135,11 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                     {
                                         if (parameterType.IsNullable)
                                         {
-                                            typeHintOnTheLeftHandSide = new CSharpTypeProperties(parameterType.Definition, false).ClassName + "?"; // Int32?
+                                            typeHintOnTheLeftHandSide = new CSharpTypeProperties(parameterType.Definition, false).ClassName; // Int32
+                                            if (EdmTypesNonNullableByDefault.Contains(typeHintOnTheLeftHandSide))
+                                            {
+                                                typeHintOnTheLeftHandSide += "?"; // Int32?
+                                            }
                                         }
                                         else
                                         {

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -120,7 +120,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                                             throw new NotSupportedException("Parameter type from URL is not found in metadata!");
                                         }
 
-                                        if (parameterType?.IsNullable == true)
+                                        if (parameterType.IsNullable)
                                         {
                                             typeHintOnTheLeftHandSide = new CSharpTypeProperties(parameterType.Definition, false).ClassName;
                                             if (EdmTypesNonNullableByDefault.Contains(typeHintOnTheLeftHandSide))


### PR DESCRIPTION
fixes #297

In the samples, we see that some of the values for action parameters are `null`. And the default generation process relies on type inference for variables. However the statement
```csharp
var parameter = null;
```
is not good enough for type inference.

This PR adds a special case for these situations where `var` is replaced by the type from the action parameter, e.g.: 
```csharp
Int32? parameter = null;
```

When the type is already a nullable type (i.e. any custom Microsoft.Graph type or System types such as String), we skip adding question mark after the type name:
```csharp
String parameter = null;
```

Also evaluated the option of inlining null as an action parameter, but that required passing the context around, so the current fix ended up being more local.

[Snippet Generation Diff](https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/31285...snippet-generation/31331)
