### PR TITLE
feature/separate-cleanup

### DIFF
--- a/pipelines/snippets.yml
+++ b/pipelines/snippets.yml
@@ -52,23 +52,7 @@ steps:
   submodules: recursive
   persistCredentials: true
 
-- pwsh: |
-    $branchName = "snippet-generation/$env:BUILD_BUILDID" # Match the spec in the GH Action
-    Write-Host "Branch path spec for the pull request will be $branchName"
-    Write-Host "##vso[task.setvariable variable=branchName]$branchName"
-  displayName: 'Calculate and set pipeline variables for this job'
-
-- pwsh: |
-    Write-Host "The new branch name will be: $env:BRANCHNAME"
-    git checkout -B $env:BRANCHNAME | Write-Host
-  displayName: 'Git: branch from master named with the build id: $(Build.BuildId)'
-  workingDirectory: 'microsoft-graph-docs'
-
-- pwsh: |
-    git config user.email "GraphTooling@service.microsoft.com"
-    git config user.name "Microsoft Graph DevX Tooling"
-  displayName: 'Git: set user config'
-  workingDirectory: 'microsoft-graph-docs'
+- template: templates/git-config.yml
 
 - task: UseDotNet@2
   displayName: 'Install dotnet core SDK'
@@ -107,27 +91,4 @@ steps:
   displayName: 'Generate snippets'
   workingDirectory: microsoft-graph-docs
 
-- pwsh: $(Build.SourcesDirectory)/microsoft-graph-explorer-api/scripts/cleanupUnusedSnippets.ps1
-  displayName: 'Cleanup unused snippets'
-  workingDirectory: microsoft-graph-docs
-
-- pwsh: |
-    Write-Host "About to add files....." -ForegroundColor Green
-    git add . | Write-Host
-    if ($env:BUILD_REASON -eq 'Manual') # Skip CI if manually running this pipeline.
-    {
-      git commit -m "Update generated files with build $env:BUILD_BUILDID [skip ci]" | Write-Host
-    }
-    else
-    {
-      git commit -m "Update generated files with build $env:BUILD_BUILDID" | Write-Host
-    }
-    Write-Host "Added and commited generated files." -ForegroundColor Green
-  displayName: 'Git: stage and commit generated files'
-  workingDirectory: 'microsoft-graph-docs'
-
-- pwsh: |
-    git push --set-upstream origin $env:BRANCHNAME | Write-Host
-    Write-Host "Pushed the results of the build to the $env:BRANCHNAME branch." -ForegroundColor Green
-  displayName: 'Git: push updates'
-  workingDirectory: 'microsoft-graph-docs'
+- template: templates/commit-changes.yml

--- a/pipelines/templates/commit-changes.yml
+++ b/pipelines/templates/commit-changes.yml
@@ -1,16 +1,23 @@
 steps:
 - pwsh: |
     Write-Host "About to add files....." -ForegroundColor Green
-    git add . | Write-Host
-    if ($env:BUILD_REASON -eq 'Manual') # Skip CI if manually running this pipeline.
-    {
-      git commit -m "Update generated files with build $env:BUILD_BUILDID [skip ci]" | Write-Host
+    $diffResult = & {git diff}
+    if($diffResult -eq $null) {
+      Write-Host "##vso[task.setvariable variable=shouldPushBranch]false"
+      Write-Host "No changes to commit." -ForegroundColor Green
+    } else {
+      git add . | Write-Host
+      if ($env:BUILD_REASON -eq 'Manual') # Skip CI if manually running this pipeline.
+      {
+        git commit -m "Update generated files with build $env:BUILD_BUILDID [skip ci]" | Write-Host
+      }
+      else
+      {
+        git commit -m "Update generated files with build $env:BUILD_BUILDID" | Write-Host
+      }
+      Write-Host "Added and commited generated files." -ForegroundColor Green
+      Write-Host "##vso[task.setvariable variable=shouldPushBranch]true"
     }
-    else
-    {
-      git commit -m "Update generated files with build $env:BUILD_BUILDID" | Write-Host
-    }
-    Write-Host "Added and commited generated files." -ForegroundColor Green
   displayName: 'Git: stage and commit generated files'
   workingDirectory: 'microsoft-graph-docs'
 
@@ -19,3 +26,4 @@ steps:
     Write-Host "Pushed the results of the build to the $env:BRANCHNAME branch." -ForegroundColor Green
   displayName: 'Git: push updates'
   workingDirectory: 'microsoft-graph-docs'
+  condition: and(succeeded(), eq(variables.shouldPushBranch, true))

--- a/pipelines/templates/commit-changes.yml
+++ b/pipelines/templates/commit-changes.yml
@@ -1,0 +1,21 @@
+steps:
+- pwsh: |
+    Write-Host "About to add files....." -ForegroundColor Green
+    git add . | Write-Host
+    if ($env:BUILD_REASON -eq 'Manual') # Skip CI if manually running this pipeline.
+    {
+      git commit -m "Update generated files with build $env:BUILD_BUILDID [skip ci]" | Write-Host
+    }
+    else
+    {
+      git commit -m "Update generated files with build $env:BUILD_BUILDID" | Write-Host
+    }
+    Write-Host "Added and commited generated files." -ForegroundColor Green
+  displayName: 'Git: stage and commit generated files'
+  workingDirectory: 'microsoft-graph-docs'
+
+- pwsh: |
+    git push --set-upstream origin $env:BRANCHNAME | Write-Host
+    Write-Host "Pushed the results of the build to the $env:BRANCHNAME branch." -ForegroundColor Green
+  displayName: 'Git: push updates'
+  workingDirectory: 'microsoft-graph-docs'

--- a/pipelines/templates/commit-changes.yml
+++ b/pipelines/templates/commit-changes.yml
@@ -26,4 +26,4 @@ steps:
     Write-Host "Pushed the results of the build to the $env:BRANCHNAME branch." -ForegroundColor Green
   displayName: 'Git: push updates'
   workingDirectory: 'microsoft-graph-docs'
-  condition: and(succeeded(), eq(variables.shouldPushBranch, true))
+  condition: and(succeeded(), eq(variables.shouldPushBranch, 'true'))

--- a/pipelines/templates/git-config.yml
+++ b/pipelines/templates/git-config.yml
@@ -1,0 +1,18 @@
+steps:
+- pwsh: |
+    $branchName = "snippet-generation/$env:BUILD_BUILDID" # Match the spec in the GH Action
+    Write-Host "Branch path spec for the pull request will be $branchName"
+    Write-Host "##vso[task.setvariable variable=branchName]$branchName"
+  displayName: 'Calculate and set pipeline variables for this job'
+
+- pwsh: |
+    Write-Host "The new branch name will be: $env:BRANCHNAME"
+    git checkout -B $env:BRANCHNAME | Write-Host
+  displayName: 'Git: branch from master named with the build id: $(Build.BuildId)'
+  workingDirectory: 'microsoft-graph-docs'
+
+- pwsh: |
+    git config user.email "GraphTooling@service.microsoft.com"
+    git config user.name "Microsoft Graph DevX Tooling"
+  displayName: 'Git: set user config'
+  workingDirectory: 'microsoft-graph-docs'

--- a/pipelines/unused-snippets.yml
+++ b/pipelines/unused-snippets.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# Pipeline for Snippet injection into docs
+# Pipeline for removing unused snippets from the docs repo
 
 trigger: none
 pr: none

--- a/pipelines/unused-snippets.yml
+++ b/pipelines/unused-snippets.yml
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Pipeline for Snippet injection into docs
+
+trigger: none
+pr: none
+schedules:
+  - cron: "30 12 * * 3"
+    displayName: Weekly Wednesday unused snippets removal
+    branches:
+      include:
+      - master
+    always: true
+
+resources:
+ repositories:
+   - repository: microsoft-graph-docs
+     type: github
+     endpoint: microsoftgraph
+     name: microsoftgraph/microsoft-graph-docs
+     ref: master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- checkout: self
+  displayName: checkout GE api
+  fetchDepth: 1
+  persistCredentials: true
+
+- checkout: microsoft-graph-docs
+  displayName: checkout docs
+  fetchDepth: 1
+  persistCredentials: true
+
+- template: templates/git-config.yml
+
+- pwsh: $(Build.SourcesDirectory)/microsoft-graph-explorer-api/scripts/cleanupUnusedSnippets.ps1
+  displayName: 'Cleanup unused snippets'
+  workingDirectory: microsoft-graph-docs
+
+- template: templates/commit-changes.yml


### PR DESCRIPTION
This pull request separates the unused snippets cleanup I added recently from the actual snippet generation.
This is because in order to make sure we're not deleting snippets that are referenced, we need to parse a lot of markdown docs, and this takes almost as much time as the generation process. It also doesn't need to happen at the same time/candence than the generation process.

So I separated it to make tests generation cycles faster.

@MIchaelmainer I don't have permissions to add a new pipeline for that repo, can you add the new one (uused-snippets) under that folder for me please? https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build?definitionScope=%5CSnippet%20Generation

Edit: this also adds a conditional statement to avoid trying to commit and push things when there are no changes. This way the pipeline doesn't fail anymore for expected reasons