### PR TITLE
feature/java-move-nongen

### DIFF
--- a/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/JavaGeneratorShould.cs
@@ -14,7 +14,7 @@ namespace CodeSnippetsReflection.Test
     {
         private const string ServiceRootUrl = "https://graph.microsoft.com/v1.0";
         private readonly IEdmModel _edmModel = CsdlReader.Parse(XmlReader.Create(CommonGeneratorShould.CleanV1Metadata));
-        private const string AuthProviderPrefix = "IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();\r\n\r\n";
+        private const string AuthProviderPrefix = "GraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();\r\n\r\n";
 
         [Fact]
         public void MapCorrectTypeForGuidReturnType()

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -43,7 +43,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 snippetModel.ResponseVariableName = CommonGenerator.EnsureVariableNameIsNotReserved(snippetModel.ResponseVariableName, languageExpressions);
 
                 /*Auth provider section*/
-                snippetBuilder.Append("IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();\r\n\r\n");
+                snippetBuilder.Append("GraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();\r\n\r\n");
                 //append any request options present
                 snippetBuilder.Append(GenerateRequestOptionsSection(snippetModel, languageExpressions));
                 /*Generate the query section of the request*/


### PR DESCRIPTION
related to https://github.com/microsoftgraph/msgraph-sdk-java/pull/615

The IGraphServiceClient interface is no more as it's a bad interface (any new root path would break people implementing it)