### PR TITLE
Use NewtonsoftJson as default converter in upgraded .NET 5.0 project

### DIFF
--- a/GraphWebApi/GraphWebApi.csproj
+++ b/GraphWebApi/GraphWebApi.csproj
@@ -43,6 +43,7 @@
     <PackageReference Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.1" />

--- a/GraphWebApi/Startup.cs
+++ b/GraphWebApi/Startup.cs
@@ -57,7 +57,7 @@ namespace GraphWebApi
             services.AddSingleton<IPermissionsStore, PermissionsStore>();
             services.AddSingleton<ISamplesStore, SamplesStore>();
             services.Configure<SamplesAdministrators>(Configuration);
-            services.AddControllers();
+            services.AddControllers().AddNewtonsoftJson();
 
             #region AppInsights
 


### PR DESCRIPTION
The upgraded .NET 5.0 project uses `System.Text.Json` as the default json converter, this PR adds `NewtonsoftJson` as the default converter. 