### PR TITLE
Snippet generation should not flatten nested OData queries

### DIFF
--- a/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
+++ b/CodeSnippetsReflection.Test/CommonGeneratorShould.cs
@@ -267,57 +267,6 @@ namespace CodeSnippetsReflection.Test
         }
         #endregion
 
-        #region Test GetListAsStringForSnippet
-        [Fact]
-        public void GetListAsStringForSnippet_ShouldReturnEmptyStringIfFieldListEmpty()
-        {
-            //Arrange
-            var fieldList = new List<string>();
-
-            //Act
-            var result = CommonGenerator.GetListAsStringForSnippet(fieldList,",");
-
-            //Assert
-            Assert.Equal("",result);
-        }
-
-        [Fact]
-        public void GetListAsStringForSnippet_ShouldReturnCommaSeparatedStringWithCommaDelimiter()
-        {
-            //Arrange
-            var fieldList = new List<string>
-            {
-                "Test",
-                "Test2",
-                "Test3"
-            };
-
-            //Act
-            var result = CommonGenerator.GetListAsStringForSnippet(fieldList, ",");
-
-            //Assert
-            Assert.Equal("Test,Test2,Test3", result);
-        }
-
-        [Fact]
-        public void GetListAsStringForSnippet_ShouldReturnUnDelimitedStringWithEmptyDelimiter()
-        {
-            //Arrange
-            var fieldList = new List<string>
-            {
-                "Test",
-                "Test2",
-                "Test3"
-            };
-
-            //Act
-            var result = CommonGenerator.GetListAsStringForSnippet(fieldList, "");
-
-            //Assert
-            Assert.Equal("TestTest2Test3", result);
-        }
-        #endregion
-
         #region Test GetEdmTypeFromIdentifier
         [Fact]
         public void GetClassNameFromIdentifier_ShouldReturnRootIdentifierOnFirstSearch()

--- a/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CSharpGenerator.cs
@@ -855,7 +855,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                 }
 
                 //return the enum type "ORed" together
-                return CommonGenerator.GetListAsStringForSnippet(enumStringList, " | ");
+                return string.Join(" | ", enumStringList);
             }
 
             return string.Empty;

--- a/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/CommonGenerator.cs
@@ -48,7 +48,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any filter queries
             if (snippetModel.FilterFieldList.Any())
             {
-                var filterResult = GetListAsStringForSnippet(snippetModel.FilterFieldList, languageExpressions.FilterExpressionDelimiter);
+                var filterResult = string.Join(languageExpressions.FilterExpressionDelimiter, snippetModel.FilterFieldList);
                 //append the filter to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.FilterExpression, filterResult));
             }
@@ -69,7 +69,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any select queries
             if (snippetModel.SelectFieldList.Any())
             {
-                var selectResult = GetListAsStringForSnippet(snippetModel.SelectFieldList, languageExpressions.SelectExpressionDelimiter);
+                var selectResult = string.Join(languageExpressions.SelectExpressionDelimiter, snippetModel.SelectFieldList);
                 //append the select result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.SelectExpression, selectResult));
             }
@@ -77,7 +77,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
             //Append any orderby queries
             if (snippetModel.OrderByFieldList.Any())
             {
-                var orderByResult = GetListAsStringForSnippet(snippetModel.OrderByFieldList, languageExpressions.OrderByExpressionDelimiter);
+                var orderByResult = string.Join(languageExpressions.OrderByExpressionDelimiter, snippetModel.OrderByFieldList);
                 //append the orderby result to the snippet
                 snippetBuilder.Append(string.Format(languageExpressions.OrderByExpression, orderByResult));
             }
@@ -255,28 +255,6 @@ namespace CodeSnippetsReflection.LanguageGenerators
 
             //just return the same value
             return edmType;
-        }
-
-
-        /// <summary>
-        /// Helper function to join string list into one string delimited with a desired character
-        /// </summary>
-        /// <param name="fieldList">List of strings that are to be concatenated to a string </param>
-        /// <param name="delimiter">Delimiter to be used to join the string elements</param>
-        public static string GetListAsStringForSnippet(IEnumerable<string> fieldList, string delimiter)
-        {
-            var result = new StringBuilder();
-            foreach (var queryOption in fieldList)
-            {
-                result.Append(queryOption + delimiter);
-            }
-            if (!string.IsNullOrEmpty(delimiter) && !string.IsNullOrEmpty(result.ToString()))
-            {
-                result.Remove(result.Length - delimiter.Length, delimiter.Length);
-            }
-
-            return result.ToString();
-
         }
 
         /// <summary>

--- a/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
+++ b/CodeSnippetsReflection/LanguageGenerators/JavaGenerator.cs
@@ -595,7 +595,7 @@ namespace CodeSnippetsReflection.LanguageGenerators
                     //handle functions/requestActions and any parameters present into collections
                     case OperationSegment operationSegment:
                         var paramList = CommonGenerator.GetParameterListFromOperationSegment(operationSegment, snippetModel, "List", false);
-                        resourcesPath.Append($"\n\t.{CommonGenerator.LowerCaseFirstLetter(operationSegment.Identifier)}({CommonGenerator.GetListAsStringForSnippet(paramList, ",")})");
+                        resourcesPath.Append($"\n\t.{CommonGenerator.LowerCaseFirstLetter(operationSegment.Identifier)}({string.Join(",", paramList)})");
                         break;
                     case ReferenceSegment _:
                         resourcesPath.Append(".reference()");

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -146,11 +146,14 @@ namespace CodeSnippetsReflection
             var queryStrings = System.Web.HttpUtility.ParseQueryString(queryString);
             foreach (var key in queryStrings.AllKeys)
             {
-                if (key == "$filter")
+                // in beta, $ is optional for OData queries.
+                // https://docs.microsoft.com/en-us/graph/query-parameters
+                var optionalKey = key.StartsWith("$") ? key.Substring(1) : key;
+                if (optionalKey == "filter")
                 {
                     FilterFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
                 }
-                else if (key == "$orderby")
+                else if (optionalKey == "orderby")
                 {
                     OrderByFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
                 }

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -148,14 +148,14 @@ namespace CodeSnippetsReflection
             {
                 // in beta, $ is optional for OData queries.
                 // https://docs.microsoft.com/en-us/graph/query-parameters
-                var optionalKey = key.StartsWith("$") ? key.Substring(1) : key;
-                if (optionalKey == "filter")
+                var optionalKey = key.StartsWith("$") ? key[1..] : key;
+                if (optionalKey.ToLowerInvariant() == "filter")
                 {
-                    FilterFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
+                    FilterFieldList = new List<string> { queryStrings[key] };
                 }
-                else if (optionalKey == "orderby")
+                else if (optionalKey.ToLowerInvariant() == "orderby")
                 {
-                    OrderByFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
+                    OrderByFieldList = new List<string> { queryStrings[key] };
                 }
             }
 

--- a/CodeSnippetsReflection/SnippetModel.cs
+++ b/CodeSnippetsReflection/SnippetModel.cs
@@ -143,21 +143,16 @@ namespace CodeSnippetsReflection
         /// <param name="queryString">Query section of url as a string</param>
         private void PopulateQueryFieldLists(string queryString)
         {
-            var querySegmentList = GetODataQuerySegments(queryString);
-
-            foreach (var queryOption in querySegmentList)
+            var queryStrings = System.Web.HttpUtility.ParseQueryString(queryString);
+            foreach (var key in queryStrings.AllKeys)
             {
-                //split the string and get the second half with the fields
-                var filterQueryOption = queryOption.Split('=').Last();
-                //split the string with the & character and get the list of params
-                var queryParams = filterQueryOption.Replace('=', ' ').Split("&").ToList();
-                if (queryOption.ToLower().Contains("filter"))
+                if (key == "$filter")
                 {
-                    FilterFieldList = queryParams;
+                    FilterFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
                 }
-                else if (queryOption.ToLower().Contains("orderby"))
+                else if (key == "$orderby")
                 {
-                    OrderByFieldList = queryParams;
+                    OrderByFieldList = queryStrings[key].Replace('=', ' ').Split("&").ToList();
                 }
             }
 
@@ -172,21 +167,6 @@ namespace CodeSnippetsReflection
                 PopulateSelectAndExpandQueryFields(queryString);
             }
 
-        }
-
-        /// <summary>
-        /// Splits the Query part of a full uri into different query segments i.e. select, expand etc
-        /// </summary>
-        /// <param name="queryString">Query section of url as a string</param>
-        /// <returns>A string collection with the query segments</returns>
-        private IEnumerable<string> GetODataQuerySegments(string queryString)
-        {
-            //Escape all special characters in the uri
-            var fullUriQuerySegment = Uri.UnescapeDataString(queryString);
-            //split by the $ symbol to get each OData Query Parser
-            var querySegmentList = fullUriQuerySegment.Split('$');
-
-            return querySegmentList;
         }
 
         /// <summary>


### PR DESCRIPTION
We don't have support for nested OData queries in our SDKs, so we can only use top level request builders for odata queries. Nested ones should be passed in as a nested string.

Fixes #287 

[Snippets diff](https://github.com/microsoftgraph/microsoft-graph-docs/compare/snippet-generation/39023?expand=1)

Note that I have removed spaces that appear in the keys of query string parameters before running the generation. Refer to the following two commits that form the base in docs:
https://github.com/microsoftgraph/microsoft-graph-docs/commit/b225d7a0da87837ede2f63403caccf9e47ba446a
https://github.com/microsoftgraph/microsoft-graph-docs/commit/20444985e436db757c8e7d353950e3775b829673

Fixes 2 V1 3 Beta compilation tests in Raptor.